### PR TITLE
Improve arc drawing resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build
 esp_idf_components
 sdkconfig.old
+.vscode

--- a/main/display/README.md
+++ b/main/display/README.md
@@ -88,10 +88,20 @@ that specify extra attributes to apply when drawing. These attributes are:
 
 1. `'(thickness w)`: Line thickness w 
 2. `'(dotted d-len d-space-len)`: Dotted or dashed lines with `d-len` long line segments separated by `d-space-len`.
-3. `'(filled)` : Specifies that the shape should be filled. 
-4. `'(rounded radius)` : Specifies that the shape should have rounded corners. 
-5. `'(scale scale-f)` : Scale the image by factor `scale-f`
-6. `'(rotate rx ry deg)` : Rotate an image around point (`rx`,`ry`), `deg` degrees. 
+3. `'(filled)`: Specifies that the shape should be filled. 
+4. `'(rounded radius)`: Specifies that the shape should have rounded corners. 
+5. `'(scale scale-f)`: Scale the image by factor `scale-f`
+6. `'(rotate rx ry deg)`: Rotate an image around point (`rx`,`ry`), `deg`
+   degrees.
+7. `'(resolution steps)`: How many lines arcs are simplified into when drawn.
+   When drawing arcs, they are simplified into a series of lines. The actual
+   amount of steps is scaled based on the arc span, with 360° specifying 100%
+   and 0° specifying 0%.
+   The default is `80`.
+   Note that this isn't just limited to `img-arc`, but every function that
+   draws any kind of arc, like actual arcs, circle segments and sectors, rounded
+   shapes, or dotted circles.
+
  
 Not all attributes are applicable to all drawing functions. The
 applicable attributes for each drawing-function is listed in the
@@ -401,6 +411,7 @@ Applicable attributes:
 1. dotted
 2. filled
 3. thickness
+4. resolution
 
 Example drawing a dashed (dotted) arc:
 ```clj
@@ -483,6 +494,7 @@ Applicable attributes:
 1. dotted
 2. filled
 3. thickness
+4. resolution
 
 Example drawing a filled circle with radius 80:
 ```clj
@@ -503,6 +515,7 @@ Applicable attributes:
 1. dotted
 2. filled
 3. thickness
+4. resolution
 
 Example drawing a thick circle-sector of 45 degrees and radius 80.
 ```clj
@@ -519,6 +532,12 @@ Draw a circle-segment. Imagine a line (chord) drawn between the points of the ci
 at angle `ang-s` and `ang-e` cutting off a circle segment. The segment is the part
 of the circle that is enclosed by the arc from `ang-s` to `ang-e` and the line drawn
 between those points on the circle.
+
+Applicable attributes:
+1. dotted
+2. filled
+3. thickness
+4. resolution
 
 Example drawing a filled circle segment.
 ```clj
@@ -632,6 +651,7 @@ Applicable attributes:
 2. filled
 3. rounded
 4. thickness
+5. resolution
 
 Example drawing a filled rectangle with rounded corners:
 

--- a/main/display/README.md
+++ b/main/display/README.md
@@ -94,13 +94,13 @@ that specify extra attributes to apply when drawing. These attributes are:
 6. `'(rotate rx ry deg)`: Rotate an image around point (`rx`,`ry`), `deg`
    degrees.
 7. `'(resolution steps)`: How many lines arcs are simplified into when drawn.
-   When drawing arcs, they are simplified into a series of lines. The actual
-   amount of steps is scaled based on the arc span, with 360° specifying 100%
-   and 0° specifying 0%.
-   The default is `80`.
+   When drawing any kind of arcs, they are simplified into a series of lines
+   where the actual amount of steps is scaled from `0` to `steps` based on the arc
+   angle span.
    Note that this isn't just limited to `img-arc`, but every function that
    draws any kind of arc, like actual arcs, circle segments and sectors, rounded
    shapes, or dotted circles.
+   The default is `80`.
 
  
 Not all attributes are applicable to all drawing functions. The

--- a/main/display/lispif_disp_extensions.c
+++ b/main/display/lispif_disp_extensions.c
@@ -721,7 +721,8 @@ static void arc(image_buffer_t *img, int x, int y, int rad, float ang_start, flo
 		ang_range += 2.0 * M_PI;
 	}
 
-	float steps = 40.0 * ang_range * (0.5 / M_PI);
+	
+	float steps = ceil(80.0 * ang_range * (0.5 / M_PI));
 
 	float ang_step = ang_range / steps;
 	float sa = sinf(ang_step);

--- a/main/display/lispif_disp_extensions.c
+++ b/main/display/lispif_disp_extensions.c
@@ -104,6 +104,7 @@ static lbm_uint symbol_rounded = 0;
 static lbm_uint symbol_dotted = 0;
 static lbm_uint symbol_scale = 0;
 static lbm_uint symbol_rotate = 0;
+static lbm_uint symbol_resolution = 0;
 
 static lbm_uint symbol_regular = 0;
 static lbm_uint symbol_gradient_x = 0;
@@ -276,6 +277,7 @@ static bool register_symbols(void) {
 	res = res && lbm_add_symbol_const("dotted", &symbol_dotted);
 	res = res && lbm_add_symbol_const("scale", &symbol_scale);
 	res = res && lbm_add_symbol_const("rotate", &symbol_rotate);
+	res = res && lbm_add_symbol_const("resolution", &symbol_resolution);
 
 	res = res && lbm_add_symbol_const("regular", &symbol_regular);
 	res = res && lbm_add_symbol_const("gradient_x", &symbol_gradient_x);
@@ -708,7 +710,7 @@ static void fill_triangle(image_buffer_t *img, int x0, int y0,
 }
 
 static void arc(image_buffer_t *img, int x, int y, int rad, float ang_start, float ang_end,
-		int thickness, bool filled, int dot1, int dot2, bool sector, bool segment, uint32_t color) {
+		int thickness, bool filled, int dot1, int dot2, int res, bool sector, bool segment, uint32_t color) {
 	ang_start *= M_PI / 180.0;
 	ang_end *= M_PI / 180.0;
 
@@ -721,8 +723,11 @@ static void arc(image_buffer_t *img, int x, int y, int rad, float ang_start, flo
 		ang_range += 2.0 * M_PI;
 	}
 
+	if (res <= 0) {
+		res = 80;
+	}
 	
-	float steps = ceil(80.0 * ang_range * (0.5 / M_PI));
+	float steps = ceilf(res * ang_range * (0.5 / M_PI));
 
 	float ang_step = ang_range / steps;
 	float sa = sinf(ang_step);
@@ -939,6 +944,7 @@ typedef struct {
 	attr_t attr_dotted;
 	attr_t attr_scale;
 	attr_t attr_rotate;
+	attr_t attr_resolution;
 } img_args_t;
 
 static img_args_t decode_args(lbm_value *args, lbm_uint argn, int num_expected) {
@@ -994,6 +1000,9 @@ static img_args_t decode_args(lbm_value *args, lbm_uint argn, int num_expected) 
 					} else if (lbm_dec_sym(arg) == symbol_rotate) {
 						attr_now = &res.attr_rotate;
 						attr_now->arg_num = 3;
+					} else if (lbm_dec_sym(arg) == symbol_resolution) {
+						attr_now = &res.attr_resolution;
+						attr_now->arg_num = 1;
 					} else {
 						return res;
 					}
@@ -1250,6 +1259,7 @@ static lbm_value ext_circle(lbm_value *args, lbm_uint argn) {
 				false,
 				lbm_dec_as_i32(arg_dec.attr_dotted.args[0]),
 				lbm_dec_as_i32(arg_dec.attr_dotted.args[1]),
+				lbm_dec_as_i32(arg_dec.attr_resolution.args[0]),
 				false, false,
 				lbm_dec_as_i32(arg_dec.args[3]));
 	} else {
@@ -1281,6 +1291,7 @@ static lbm_value ext_arc(lbm_value *args, lbm_uint argn) {
 			arg_dec.attr_filled.is_valid,
 			lbm_dec_as_i32(arg_dec.attr_dotted.args[0]),
 			lbm_dec_as_i32(arg_dec.attr_dotted.args[1]),
+			lbm_dec_as_i32(arg_dec.attr_resolution.args[0]),
 			false, false,
 			lbm_dec_as_i32(arg_dec.args[5]));
 
@@ -1304,6 +1315,7 @@ static lbm_value ext_circle_sector(lbm_value *args, lbm_uint argn) {
 			arg_dec.attr_filled.is_valid,
 			lbm_dec_as_i32(arg_dec.attr_dotted.args[0]),
 			lbm_dec_as_i32(arg_dec.attr_dotted.args[1]),
+			lbm_dec_as_i32(arg_dec.attr_resolution.args[0]),
 			true, false,
 			lbm_dec_as_i32(arg_dec.args[5]));
 
@@ -1318,17 +1330,18 @@ static lbm_value ext_circle_segment(lbm_value *args, lbm_uint argn) {
 	}
 
 	arc(arg_dec.img,
-			lbm_dec_as_i32(arg_dec.args[0]),
-			lbm_dec_as_i32(arg_dec.args[1]),
-			lbm_dec_as_i32(arg_dec.args[2]),
-			lbm_dec_as_float(arg_dec.args[3]),
-			lbm_dec_as_float(arg_dec.args[4]),
-			lbm_dec_as_i32(arg_dec.attr_thickness.args[0]),
-			arg_dec.attr_filled.is_valid,
-			lbm_dec_as_i32(arg_dec.attr_dotted.args[0]),
-			lbm_dec_as_i32(arg_dec.attr_dotted.args[1]),
-			false, true,
-			lbm_dec_as_i32(arg_dec.args[5]));
+		lbm_dec_as_i32(arg_dec.args[0]),
+		lbm_dec_as_i32(arg_dec.args[1]),
+		lbm_dec_as_i32(arg_dec.args[2]),
+		lbm_dec_as_float(arg_dec.args[3]),
+		lbm_dec_as_float(arg_dec.args[4]),
+		lbm_dec_as_i32(arg_dec.attr_thickness.args[0]),
+		arg_dec.attr_filled.is_valid,
+		lbm_dec_as_i32(arg_dec.attr_dotted.args[0]),
+		lbm_dec_as_i32(arg_dec.attr_dotted.args[1]),
+		lbm_dec_as_i32(arg_dec.attr_resolution.args[0]),
+		false, true,
+		lbm_dec_as_i32(arg_dec.args[5]));
 
 	return ENC_SYM_TRUE;
 }
@@ -1350,6 +1363,7 @@ static lbm_value ext_rectangle(lbm_value *args, lbm_uint argn) {
 	uint32_t color = lbm_dec_as_i32(arg_dec.args[4]);
 	int dot1 = lbm_dec_as_i32(arg_dec.attr_dotted.args[0]);
 	int dot2 = lbm_dec_as_i32(arg_dec.attr_dotted.args[1]);
+	int resolution = lbm_dec_as_i32(arg_dec.attr_resolution.args[0]);
 
 	if (arg_dec.attr_rounded.is_valid) {
 		if (arg_dec.attr_filled.is_valid) {
@@ -1362,13 +1376,13 @@ static lbm_value ext_rectangle(lbm_value *args, lbm_uint argn) {
 			fill_circle(img, x + width - rad, y + height - rad, rad, color);
 		} else {
 			line(img, x + rad, y, x + width - rad, y, thickness, dot1, dot2, color);
-			arc(img, x + rad, y + rad, rad, 180, 270, thickness, false, dot1, dot2, false, false, color);
+			arc(img, x + rad, y + rad, rad, 180, 270, thickness, false, dot1, dot2, resolution, false, false, color);
 			line(img, x + rad, y + height, x + width - rad, y + height, thickness, dot1, dot2, color);
-			arc(img, x + rad, y + height - rad, rad, 90, 180, thickness, false, dot1, dot2, false, false, color);
+			arc(img, x + rad, y + height - rad, rad, 90, 180, thickness, false, dot1, dot2, resolution, false, false, color);
 			line(img, x, y + rad, x, y + height - rad, thickness, dot1, dot2, color);
-			arc(img, x + width - rad, y + height - rad, rad, 0, 90, thickness, false, dot1, dot2, false, false, color);
+			arc(img, x + width - rad, y + height - rad, rad, 0, 90, thickness, false, dot1, dot2, resolution, false, false, color);
 			line(img, x + width, y + rad, x + width, y + height - rad, thickness, dot1, dot2, color);
-			arc(img, x + width - rad, y + rad, rad, 270, 0, thickness, false, dot1, dot2, false, false, color);
+			arc(img, x + width - rad, y + rad, rad, 270, 0, thickness, false, dot1, dot2, resolution, false, false, color);
 		}
 	} else {
 		rectangle(img,


### PR DESCRIPTION
Fixed the bug where arc steps were rounded inconsistently.

I've also increased the default resolution when drawing arcs from 40 to 80.

Also added the new attribute `resolution` to the following functions to enable the user to manually specify a resolution:
- `img-arc`
- `img-circle`
- `img-circle-sector`
- `img-circle-segment`
- `img-resolution`

I also added the attribute to the documentation. The explanation might be a bit long though ;)

If anything is wrong or can be improved, just tell me.