### PR TITLE
Added the tcp-recv-to-char and buf-resize extensions

### DIFF
--- a/main/ble/README.md
+++ b/main/ble/README.md
@@ -209,13 +209,32 @@ byte-array `"hello"`, and then queried:
 
 Set the value of the attribute to the provided value. `attr-handle` should be a
 number that was returned by [`ble-add-service`](#ble-add-service) and `value` a byte
-array.
+array. **Note** that the raw byte without modification will be stored, and since strings are null
+terminated in LBM, setting the value to a string literal will include the
+terminating null byte. You will have to create a copy of the byte array without
+the final byte to avoid this behaviour. Here is an example function that does
+this using
+[`bufcpy`](https://github.com/vedderb/bldc/blob/master/lispBM/README.md#bufcpy):
+```clj
+(defun trim-null-byte (str) {
+    (var len (str-len str))
+    (var cpy (bufcreate len))
+    (bufcpy cpy 0 str 0 len)
+    cpy
+})
+```
 
 Providing an invalid handle will throw an `eval_error`.
 
 Setting the value of a characteristic automatically sends notifications or
 indications to subscribing clients if those flags were set when the
 characteristic was defined.
+
+Example that sets the value of the attribute with the handle 40 to "hello":
+```clj
+(ble-attr-set-value 40 "hello")
+; it now contains the bytes [0x68 0x65 0x6c 0x6c 0x6f 0x0]
+```
 
 ### `ble-get-services`
 

--- a/main/ble/custom_ble.c
+++ b/main/ble/custom_ble.c
@@ -457,7 +457,7 @@ static void gatts_event_handler(
 				"created attribute table; status: %u, svc_inst_id: %u, "
 				"num_handle: %u, waiting_add_service_index: %d",
 				param->add_attr_tab.status, param->add_attr_tab.svc_inst_id,
-				param->add_attr_tab.num_handle, waiting_add_service_index,
+				param->add_attr_tab.num_handle, waiting_add_service_index
 			);
 			STORED_LOGF(
 				"svc_uuid (%u): %s", param->add_attr_tab.svc_uuid.len,

--- a/main/commands.h
+++ b/main/commands.h
@@ -24,6 +24,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "hw.h"
+
 typedef void (*send_func_t)(unsigned char *, unsigned int);
 
 // Functions

--- a/main/lbm_vesc_utils.c
+++ b/main/lbm_vesc_utils.c
@@ -25,6 +25,9 @@
 #include "heap.h"
 #include "eval_cps.h"
 #include "lbm_flat_value.h"
+#include "commands.h"
+
+#include "lbm_vesc_utils.h"
 
 bool lbm_add_symbol_const_if_new(char *name, lbm_uint *id) {
 	if (!lbm_get_symbol_by_name(name, id) && !lbm_add_symbol_const(name, id)) {
@@ -85,6 +88,15 @@ lbm_value lbm_allocate_empty_list_grid(lbm_uint height, lbm_uint width) {
 	return outer;
 }
 
+bool lbm_memory_shrink_bytes(void *array, lbm_uint size_bytes) {
+	lbm_uint size_words = size_bytes / LBM_WORD_SIZE;
+	if (size_bytes % LBM_WORD_SIZE != 0) {
+		size_words += 1;
+	}
+	
+	return lbm_memory_shrink((lbm_uint *)array, size_words) > 0;
+}
+
 bool lbm_array_shrink(lbm_value array, lbm_uint new_size) {
 	if (!lbm_is_array_rw(array)) {
 		return false;
@@ -92,7 +104,7 @@ bool lbm_array_shrink(lbm_value array, lbm_uint new_size) {
 
 	lbm_array_header_t *header = (lbm_array_header_t *)lbm_car(array);
 
-	if (!lbm_memory_shrink(header->data, new_size)) {
+	if (!lbm_memory_shrink_bytes(header->data, new_size)) {
 		return false;
 	}
 	header->size = new_size;

--- a/main/lbm_vesc_utils.h
+++ b/main/lbm_vesc_utils.h
@@ -145,7 +145,7 @@ lbm_value lbm_allocate_empty_list_grid(lbm_uint height, lbm_uint width);
  * or if the new size was larger than the previous (note that since this
  * function converts bytes to words, a larger size in bytes might not cause it
  * to fail, as the size in words could still be the same). Otherwise true is
- * returned.
+ * returned. 
 */
 bool lbm_memory_shrink_bytes(void *ptr, lbm_uint size_bytes);
 

--- a/main/lbm_vesc_utils.h
+++ b/main/lbm_vesc_utils.h
@@ -24,6 +24,11 @@
 #include "heap.h"
 #include "lbm_flat_value.h"
 
+// Is this the right place to define this?
+/**
+ * Bytes per word in the LBM memory.
+*/
+#define LBM_WORD_SIZE 4
 
 /**
  * Add symbol to the symbol table if it doesn't already exist.
@@ -123,6 +128,26 @@ lbm_value lbm_allocate_empty_list(lbm_uint len);
  * @return The allocated list, or ENC_SYM_MERROR when out of memory.
 */
 lbm_value lbm_allocate_empty_list_grid(lbm_uint height, lbm_uint width);
+
+/**
+ * Wrapper around lbm_memory_shrink that takes number of bytes instead of number
+ * of words. Shrinks the size of an pointer allocated in LBM memory to the
+ * smallest possible size while still having capacity for the specified amount
+ * of bytes.
+ * 
+ * @param ptr Pointer to the allocated segment in LBM memory. Should have been
+ * obtained through lbm_malloc or other similar way at some point.
+ * @param size_bytes The new capacity of the allocation in bytes. Must be
+ * smaller or equal to the previous capacity.
+ * @return If the operation succeeded. The return value of lbm_memory_shrink is
+ * directly passed through, that is: false is returned either if ptr didn't
+ * point into the LBM memory/didn't point to the start of an allocated segment
+ * or if the new size was larger than the previous (note that since this
+ * function converts bytes to words, a larger size in bytes might not cause it
+ * to fail, as the size in words could still be the same). Otherwise true is
+ * returned.
+*/
+bool lbm_memory_shrink_bytes(void *ptr, lbm_uint size_bytes);
 
 /**
  * Shrink an lbm array to the new specified size.

--- a/main/wifi/README.md
+++ b/main/wifi/README.md
@@ -393,7 +393,6 @@ receive the first message terminated by a zero byte:
 Example where we receive the first line of an HTTP request. This example should
 be runnable without any modifications, as example.com is a real domain:
 ```clj
-; LBM sadly doesn't support newline character literals.
 (def char-newline 10b)
 
 (def socket (tcp-connect "example.com" 80))


### PR DESCRIPTION
Added the `tcp-recv-to-char` extension for receiving data until a character is encountered.

Also added a `buf-resize` extension for efficiently growing or shrinking the length of byte-arrays.

I will open a pull request for the [bldc](https://github.com/vedderb/bldc) repository with the `buf-resize` extension as well as updated docs very soon.