### PR TITLE
Fail on const_heap_write if attempting to write to occupied memory

### DIFF
--- a/main/lispif.c
+++ b/main/lispif.c
@@ -810,6 +810,11 @@ static bool const_heap_write(lbm_uint ix, lbm_uint w) {
 		return true;
 	}
 
+	if (const_heap_ptr[ix] != 0xffffffff) {
+		commands_printf_lisp("Attempted to write to const heap at %d, but it is already occupied", ix);
+		return false;
+	}
+
 	uint32_t offset = (uint32_t)const_heap_ptr - (uint32_t)flash_helper_code_data_raw(CODE_IND_LISP) + sizeof(lbm_uint) * ix;
 	flash_helper_write_code(CODE_IND_LISP, offset, (uint8_t*)&w, sizeof(lbm_uint));
 


### PR DESCRIPTION
This prevents incorrect usage of @const-start 