### PR TITLE
Add SPI NAND Flash support with integrated VESC Tool

### DIFF
--- a/main/lispif_vesc_extensions.c
+++ b/main/lispif_vesc_extensions.c
@@ -79,6 +79,12 @@
 #include <ctype.h>
 #include <stdarg.h>
 
+#if defined(SD_PIN_MOSI)
+const char *base_path = "/sdcard/";
+#elif defined(NAND_PIN_MOSI)
+const char *base_path = "/nandflash/";
+#endif
+
 typedef struct {
 	// BMS
 	lbm_uint v_tot;
@@ -3435,8 +3441,8 @@ static lbm_value ext_f_open(lbm_value *args, lbm_uint argn) {
 		return ENC_SYM_TERROR;
 	}
 
-	char path_full[strlen(path) + strlen("/sdcard/") + 1];
-	strcpy(path_full, "/sdcard/");
+	char path_full[strlen(path) + strlen(base_path) + 1];
+	strcpy(path_full, base_path);
 	strcat(path_full, path);
 
 	FILE *f = fopen(path_full, mode);
@@ -3618,8 +3624,8 @@ static lbm_value ext_f_mkdir(lbm_value *args, lbm_uint argn) {
 		return ENC_SYM_TERROR;
 	}
 
-	char path_full[strlen(path) + strlen("/sdcard/") + 1];
-	strcpy(path_full, "/sdcard/");
+	char path_full[strlen(path) + strlen(base_path) + 1];
+	strcpy(path_full, base_path);
 	strcat(path_full, path);
 
 	return mkdir(path_full, 0775) == 0 ? ENC_SYM_TRUE : ENC_SYM_NIL;
@@ -3635,8 +3641,8 @@ static lbm_value ext_f_rm(lbm_value *args, lbm_uint argn) {
 		return ENC_SYM_TERROR;
 	}
 
-	char path_full[strlen(path) + strlen("/sdcard/") + 1];
-	strcpy(path_full, "/sdcard/");
+	char path_full[strlen(path) + strlen(base_path) + 1];
+	strcpy(path_full, base_path);
 	strcat(path_full, path);
 
 	return utils_rmtree(path_full) ? ENC_SYM_TRUE : ENC_SYM_NIL;
@@ -3652,8 +3658,8 @@ static lbm_value ext_f_ls(lbm_value *args, lbm_uint argn) {
 		return ENC_SYM_TERROR;
 	}
 
-	char path_full[strlen(path) + strlen("/sdcard/") + 1];
-	strcpy(path_full, "/sdcard/");
+	char path_full[strlen(path) + strlen(base_path) + 1];
+	strcpy(path_full, base_path);
 	strcat(path_full, path);
 
 	lbm_value res = ENC_SYM_NIL;
@@ -3740,8 +3746,8 @@ static lbm_value ext_f_size(lbm_value *args, lbm_uint argn) {
 			return ENC_SYM_TERROR;
 		}
 
-		char path_full[strlen(path) + strlen("/sdcard/") + 1];
-		strcpy(path_full, "/sdcard/");
+		char path_full[strlen(path) + strlen(base_path) + 1];
+		strcpy(path_full, base_path);
 		strcat(path_full, path);
 
 		FILE *f = fopen(path_full, "r");
@@ -3771,21 +3777,21 @@ static lbm_value ext_f_rename(lbm_value *args, lbm_uint argn) {
 		return ENC_SYM_TERROR;
 	}
 
-	char *old_full = lbm_malloc(strlen(old_name) + strlen("/sdcard/") + 1);
+	char *old_full = lbm_malloc(strlen(old_name) + strlen(base_path) + 1);
 	if (!old_full) {
 		return ENC_SYM_MERROR;
 	}
 
-	char *new_full = lbm_malloc(strlen(new_name) + strlen("/sdcard/") + 1);
+	char *new_full = lbm_malloc(strlen(new_name) + strlen(base_path) + 1);
 	if (!new_full) {
 		lbm_free(old_full);
 		return ENC_SYM_MERROR;
 	}
 
-	strcpy(old_full, "/sdcard/");
+	strcpy(old_full, base_path);
 	strcat(old_full, old_name);
 
-	strcpy(new_full, "/sdcard/");
+	strcpy(new_full, base_path);
 	strcat(new_full, new_name);
 
 	lbm_value res = rename(old_full, new_full) == 0 ? ENC_SYM_TRUE : ENC_SYM_NIL;
@@ -3802,7 +3808,7 @@ static lbm_value ext_f_fatinfo(lbm_value *args, lbm_uint argn) {
 
 	uint64_t total = 0;
 	uint64_t free = 0;
-	esp_vfs_fat_info("/sdcard", &total, &free);
+	esp_vfs_fat_info(base_path, &total, &free);
 	total /= 1024;
 	total /= 1024;
 	free /= 1024;

--- a/main/log.c
+++ b/main/log.c
@@ -22,6 +22,7 @@
 #include "nmea.h"
 
 #include "esp_vfs_fat.h"
+#include "esp_vfs_fat_nand.h"
 #include "sdmmc_cmd.h"
 #include "esp_vfs.h"
 #include "buffer.h"
@@ -49,6 +50,7 @@ typedef struct {
 // Private variables
 static sdmmc_host_t m_host = SDSPI_HOST_DEFAULT();
 static sdmmc_card_t *m_card = 0;
+static spi_nand_flash_device_t *nand_flash_device_handle;
 
 static volatile log_header m_headers[LOG_MAX_FIELDS];
 
@@ -310,6 +312,61 @@ void log_unmount_card(void) {
 	}
 
 	spi_bus_free(m_host.slot);
+}
+
+bool log_mount_nand_flash(int pin_mosi, int pin_miso, int pin_sck, int pin_cs, int freq) {
+	esp_err_t ret;
+
+	const spi_bus_config_t bus_config = {
+			.mosi_io_num = pin_mosi,
+			.miso_io_num = pin_miso,
+			.sclk_io_num = pin_sck,
+			.quadwp_io_num = -1,
+			.quadhd_io_num = -1,
+			.max_transfer_sz = 32,
+	};
+
+	//Initialize the SPI bus
+	spi_bus_initialize(SPI2_HOST, &bus_config, SPI_DMA_CH_AUTO);
+
+	spi_device_interface_config_t devcfg = {
+			.clock_speed_hz = freq * 1000,
+			.mode = 0,
+			.spics_io_num = pin_cs,
+			.queue_size = 10,
+			.flags = SPI_DEVICE_HALFDUPLEX,
+	};
+
+	spi_device_handle_t spi;
+	spi_bus_add_device(SPI2_HOST, &devcfg, &spi);
+
+	spi_nand_flash_config_t nand_flash_config = {
+			.device_handle = spi,
+	};
+
+	spi_nand_flash_init_device(&nand_flash_config, &nand_flash_device_handle);
+
+	esp_vfs_fat_mount_config_t config = {
+			.max_files = 4,
+			.format_if_mount_failed = true,
+			.allocation_unit_size = 16 * 1024
+	};
+
+	ret = esp_vfs_fat_nand_mount("/nandflash", nand_flash_device_handle, &config);
+
+	if (ret != ESP_OK) {
+		return false;
+	}
+
+	return true;
+}
+
+void log_unmount_nand_flash (void) {
+	if (nand_flash_device_handle) {
+		esp_vfs_fat_nand_unmount("/nandflash", nand_flash_device_handle);
+	}
+
+	 spi_nand_flash_deinit_device(nand_flash_device_handle);
 }
 
 bool log_init(void) {

--- a/main/log.h
+++ b/main/log.h
@@ -29,6 +29,8 @@
 bool log_init(void);
 bool log_mount_card(int pin_mosi, int pin_miso, int pin_sck, int pin_cs, int freq);
 void log_unmount_card(void);
+bool log_mount_nand_flash(int pin_mosi, int pin_miso, int pin_sck, int pin_cs, int freq);
+void log_unmount_nand_flash (void);
 void log_process_packet(unsigned char *data, unsigned int len);
 
 #endif /* MAIN_LOG_H_ */

--- a/main/main.c
+++ b/main/main.c
@@ -159,6 +159,9 @@ void app_main(void) {
 #ifdef SD_PIN_MOSI
 	log_mount_card(SD_PIN_MOSI, SD_PIN_MISO, SD_PIN_SCK, SD_PIN_CS, SDMMC_FREQ_DEFAULT);
 #endif
+#ifdef NAND_PIN_MOSI
+	log_mount_nand_flash(NAND_PIN_MOSI, NAND_PIN_MISO, NAND_PIN_SCK, NAND_PIN_CS, FLASH_FREQ_KHZ);
+#endif
 
 #ifndef HW_EARLY_LBM_INIT
 	HW_INIT_HOOK();


### PR DESCRIPTION
**SPI NAND Flash**

This pull request introduces code to the project to enable the use of NAND flash memory, providing non-volatile data storage. This addition is particularly beneficial for users looking for:

- lower cost.
- Easy integration into embedded systems.

**SPI Interface**

The communication between the NAND flash memory and the microcontroller is carried out through the SPI protocol, which facilitates fast read and write operations and seamless integration.

**Espressif `spi_nand_flash` Library**

The presented code is based on the Espressif `spi_nand_flash` library and has been rigorously tested with read and write algorithms to ensure robust error handling. It offers functionalities equivalent to those of the SD card, with the exception of a minor issue related to the `f-fatinfo` function.

**Compatibility with SPI NAND Flash Chips**

The `spi_nand_flash` component is compatible with chips from the following manufacturers and models:

- **Winbond:** W25N01GVxxxG/T/R, W25N512GVxIG/IT, W25N512GWxxR/T, W25N01JWxxxG/T
- **Gigadevice:** GD5F1GQ5UExxG, GD5F1GQ5RExxG, GD5F2GQ5UExxG, GD5F2GQ5RExxG, GD5F4GQ6UExxG, GD5F4GQ6RExxG
- **Alliance:** AS5F31G04SND-08LIN, AS5F32G04SND-08LIN, AS5F12G04SND-10LIN, AS5F34G04SND-08LIN, AS5F14G04SND-10LIN, AS5F38G04SND-08LIN, AS5F18G04SND-10LIN

A memory was used to verify the library: W25N01GVZ

**Definition of spi pins**

To use the functions, it is necessary to define the SPI pins and frequency in the device's .h file using the following predefined names, as they are used in the code:

// NAND-memory
#define NAND_PIN_MOSI
#define NAND_PIN_MISO
#define NAND_PIN_SCK
#define NAND_PIN_CS
#define FLASH_FREQ_KHZ

**Note**

It is important to clarify that currently, both file systems cannot be used simultaneously; you must choose between the SD card or the NAND flash memory.