### PR TITLE
Reset MTU size on connect

### DIFF
--- a/main/comm_ble.c
+++ b/main/comm_ble.c
@@ -43,13 +43,14 @@
 #include "main.h"
 
 #define GATTS_CHAR_VAL_LEN_MAX 255
+#define DEFAULT_BLE_MTU 20 // 23 for default mtu and 3 bytes for ATT headers
 #define BLE_CHAR_COUNT 2
 #define BLE_SERVICE_HANDLE_NUM (1 + (3 * BLE_CHAR_COUNT))
 #define ADV_CFG_FLAG (1 << 0)
 #define SCAN_RSP_CFG_FLAG (1 << 1)
 
 static bool is_connected = false;
-static uint16_t ble_current_mtu = 20;
+static uint16_t ble_current_mtu = DEFAULT_BLE_MTU;
 
 static uint16_t notify_conn_id = 0;
 static esp_gatt_if_t notify_gatts_if;
@@ -585,6 +586,7 @@ static void gatts_event_handler(
 			}
 
 			gatts_profile.conn_id = param->connect.conn_id;
+			ble_current_mtu = DEFAULT_BLE_MTU; 
 			is_connected = true;
 			LED_BLUE_ON();
 


### PR DESCRIPTION
Reset to standard MTU when establishing BLE connection. This ensures that any connecting device isn't forced to negotiate a new MTU size after an existing app/device negotiates any MTU size other than the default.

While this isn't an issue for VESC Tool itself, it can create issues with third-party apps, seemingly only on Android.