### PR TITLE
Include USER_EXTENSION_STORAGE_SIZE with lbm_init

### DIFF
--- a/main/lispif.c
+++ b/main/lispif.c
@@ -698,7 +698,7 @@ bool lispif_restart(bool print, bool load_code, bool load_imports) {
 					bitmap_array, bitmap_size,
 					GC_STACK_SIZE,
 					PRINT_STACK_SIZE,
-					extension_storage, EXTENSION_STORAGE_SIZE);
+					extension_storage, EXTENSION_STORAGE_SIZE + USER_EXTENSION_STORAGE_SIZE);
 			lbm_eval_init_events(20);
 
 			lbm_set_timestamp_us_callback(timestamp_callback);
@@ -720,7 +720,7 @@ bool lispif_restart(bool print, bool load_code, bool load_imports) {
 					bitmap_array, bitmap_size,
 					GC_STACK_SIZE,
 					PRINT_STACK_SIZE,
-					extension_storage, EXTENSION_STORAGE_SIZE);
+					extension_storage, EXTENSION_STORAGE_SIZE + USER_EXTENSION_STORAGE_SIZE);
 			lbm_eval_init_events(20);
 		}
 


### PR DESCRIPTION
I noticed the extra USER_EXTENSION_STORAGE_SIZE define was not included with the extension_storage_size parameter of lbm_init