### PR TITLE
Add support for hwconf env variables and `fw_info` terminal command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ build
 esp_idf_components
 sdkconfig.old
 .vscode
+
+# These should maybe be committed instead, but they weren't before and I don't
+# feel like making that decision right now...
+managed_components/
+dependencies.lock

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,4 +8,17 @@ include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 get_filename_component(ProjectId ${CMAKE_CURRENT_LIST_DIR} NAME)
 string(REPLACE " " "_" ProjectId ${ProjectId})
 project(${ProjectId})
+
+if((DEFINED ENV{HW_SRC}) OR (DEFINED ENV{HW_HEADER}))
+    if(NOT DEFINED ENV{HW_SRC})
+        message(FATAL_ERROR "HW_SRC not defined while HW_HEADER is set. You must either set both or none.")
+    endif()
+    if(NOT DEFINED ENV{HW_HEADER})
+        message(FATAL_ERROR "HW_HEADER not defined while HW_SRC is set. You must either set both or none.")
+    endif()
+    
+    idf_build_set_property(COMPILE_OPTIONS "-DHW_SOURCE=\"$ENV{HW_SRC}\"" APPEND)
+    idf_build_set_property(COMPILE_OPTIONS "-DHW_HEADER=\"$ENV{HW_HEADER}\"" APPEND)
+endif()
+
 idf_build_set_property(COMPILE_OPTIONS "-fdiagnostics-color=always" APPEND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ get_filename_component(ProjectId ${CMAKE_CURRENT_LIST_DIR} NAME)
 string(REPLACE " " "_" ProjectId ${ProjectId})
 project(${ProjectId})
 
+include(cmake/git_rev_parse.cmake)
+
 if((DEFINED ENV{HW_SRC}) OR (DEFINED ENV{HW_HEADER}))
     if(NOT DEFINED ENV{HW_SRC})
         message(FATAL_ERROR "HW_SRC not defined while HW_HEADER is set. You must either set both or none.")
@@ -19,6 +21,31 @@ if((DEFINED ENV{HW_SRC}) OR (DEFINED ENV{HW_HEADER}))
     
     idf_build_set_property(COMPILE_OPTIONS "-DHW_SOURCE=\"$ENV{HW_SRC}\"" APPEND)
     idf_build_set_property(COMPILE_OPTIONS "-DHW_HEADER=\"$ENV{HW_HEADER}\"" APPEND)
+endif()
+
+git_describe(GIT_COMMIT_HASH ".")
+# get_git_head_revision(GIT_COMMIT_REF GIT_COMMIT_HASH ".")
+
+if(DEFINED ENV{GIT_COMMIT_HASH})
+    set(GIT_COMMIT_HASH $ENV{GIT_COMMIT_HASH})
+else()
+    git_describe(GIT_COMMIT_HASH ".")
+endif()
+
+if(DEFINED ENV{GIT_BRANCH_NAME})
+    set(GIT_BRANCH_NAME $ENV{GIT_BRANCH_NAME})
+else()
+    git_rev_parse(GIT_BRANCH_NAME "." "--abbrev-ref" "HEAD")
+endif()
+
+idf_build_set_property(COMPILE_DEFINITIONS "GIT_COMMIT_HASH=\"${GIT_COMMIT_HASH}\"" APPEND)
+idf_build_set_property(COMPILE_DEFINITIONS "GIT_BRANCH_NAME=\"${GIT_BRANCH_NAME}\"" APPEND)
+
+if(DEFINED ENV{USER_GIT_COMMIT_HASH})
+    idf_build_set_property(COMPILE_DEFINITIONS "USER_GIT_COMMIT_HASH=\"$ENV{USER_GIT_COMMIT_HASH}\"" APPEND)
+endif()
+if(DEFINED ENV{USER_GIT_BRANCH_NAME})
+    idf_build_set_property(COMPILE_DEFINITIONS "USER_GIT_BRANCH_NAME=\"$ENV{USER_GIT_BRANCH_NAME}\"" APPEND)
 endif()
 
 idf_build_set_property(COMPILE_OPTIONS "-fdiagnostics-color=always" APPEND)

--- a/cmake/git_rev_parse.cmake
+++ b/cmake/git_rev_parse.cmake
@@ -1,0 +1,32 @@
+function(git_rev_parse _var _repo_dir)
+    if(NOT GIT_FOUND)
+        find_package(Git QUIET)
+    endif()
+    if(NOT GIT_FOUND)
+        set(${_var} "GIT-NOTFOUND" PARENT_SCOPE)
+        return()
+    endif()
+
+    execute_process(COMMAND
+        "${GIT_EXECUTABLE}"
+        "-C"
+        ${_repo_dir}
+        rev-parse
+        ${ARGN}
+        WORKING_DIRECTORY
+        "${CMAKE_CURRENT_SOURCE_DIR}"
+        RESULT_VARIABLE
+        res
+        OUTPUT_VARIABLE
+        out
+        ERROR_VARIABLE
+        error
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT res EQUAL 0)
+        string(STRIP "${error}" error)
+        message(STATUS "git rev-parse returned '${error}'")
+        set(out "${out}-${res}-NOTFOUND")
+    endif()
+
+    set(${_var} "${out}" PARENT_SCOPE)
+endfunction()

--- a/main/terminal.c
+++ b/main/terminal.c
@@ -189,8 +189,6 @@ void terminal_process_string(char *str) {
 		commands_printf("Firmware          : %d.%d", FW_VERSION_MAJOR, FW_VERSION_MINOR);
 		commands_printf("Hardware          : %s", HW_NAME);
 
-		commands_printf("IDF Version       : %s", IDF_VER);
-
 		commands_printf("BLE MTU           : %d", comm_ble_mtu_now());
 		commands_printf("BLE Connected     : %d", comm_ble_is_connected());
 		commands_printf("Custom BLE Started: %d", custom_ble_started());
@@ -230,6 +228,20 @@ void terminal_process_string(char *str) {
 
 		commands_printf("Reset Reason      : %d", esp_reset_reason());
 
+		commands_printf(" ");
+	} else if (strcmp(argv[0], "fw_info") == 0) {
+		commands_printf("Firmware   : %d.%d", FW_VERSION_MAJOR, FW_VERSION_MINOR);
+		commands_printf("Hardware   : %s", HW_NAME);
+		commands_printf("Git Branch : %s", GIT_BRANCH_NAME);
+		commands_printf("Git Hash   : %s", GIT_COMMIT_HASH);
+		commands_printf("IDF Version: %s", IDF_VER);
+	
+#ifdef USER_GIT_BRANCH_NAME
+		commands_printf("User Git Branch: %s", USER_GIT_BRANCH_NAME);
+#endif
+#ifdef USER_GIT_COMMIT_HASH
+		commands_printf("User Git Hash  : %s", USER_GIT_COMMIT_HASH);
+#endif
 		commands_printf(" ");
 	} else if (strcmp(argv[0], "can_scan") == 0) {
 		bool found = false;
@@ -274,6 +286,9 @@ void terminal_process_string(char *str) {
 
 		commands_printf("hw_status");
 		commands_printf("  Print some hardware status information.");
+
+		commands_printf("fw_info");
+		commands_printf("  Print detailed firmware info.");
 
 		commands_printf("can_scan");
 		commands_printf("  Scan CAN-bus using ping commands, and print all devices that are found.");

--- a/main/terminal.c
+++ b/main/terminal.c
@@ -75,6 +75,8 @@ const char* utils_hw_type_to_string(HW_TYPE hw) {
 }
 
 void terminal_process_string(char *str) {
+	commands_printf("-> %s\n", str);
+	
 	enum { kMaxArgs = 64 };
 	int argc = 0;
 	char *argv[kMaxArgs];
@@ -94,8 +96,6 @@ void terminal_process_string(char *str) {
 	for(int i = 0; argv[0][i] != '\0'; i++){
 		argv[0][i] = tolower(argv[0][i]);
 	}
-	
-	commands_printf("> %s", argv[0]);
 
 	for (int i = 0;i < callback_write;i++) {
 		if (callbacks[i].cbf != 0 && strcmp(argv[0], callbacks[i].command) == 0) {


### PR DESCRIPTION
Added support for supplying custom hw configuration files through environment variables `HW_SRC` and `HW_HEADER`, avoiding the need to modify the tree content.

Also added the `fw_info` command which prints the git commit details the firmware was built with. There is an option to specify user git commit details when building meant for projects with their own repo which use vesc_express. These are then also printed by `fw_info`.

Additionally improved the terminal prompt.

I've also opened similar PRs for the other VESC firmwares:
- https://github.com/vedderb/bldc/pull/772
- https://github.com/vedderb/vesc_bms_fw/pull/21
- https://github.com/vedderb/vesc_gpstm/pull/1