### PR TITLE
Infra/Reduced build times when changing HW Config file environment variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,18 +11,6 @@ project(${ProjectId})
 
 include(cmake/git_rev_parse.cmake)
 
-if((DEFINED ENV{HW_SRC}) OR (DEFINED ENV{HW_HEADER}))
-    if(NOT DEFINED ENV{HW_SRC})
-        message(FATAL_ERROR "HW_SRC not defined while HW_HEADER is set. You must either set both or none.")
-    endif()
-    if(NOT DEFINED ENV{HW_HEADER})
-        message(FATAL_ERROR "HW_HEADER not defined while HW_SRC is set. You must either set both or none.")
-    endif()
-    
-    idf_build_set_property(COMPILE_OPTIONS "-DHW_SOURCE=\"$ENV{HW_SRC}\"" APPEND)
-    idf_build_set_property(COMPILE_OPTIONS "-DHW_HEADER=\"$ENV{HW_HEADER}\"" APPEND)
-endif()
-
 git_describe(GIT_COMMIT_HASH ".")
 # get_git_head_revision(GIT_COMMIT_REF GIT_COMMIT_HASH ".")
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ cd esp-idf-v5.2.2/
 
 At the moment development is done using the stable 5.2.2-release.
 
-## Compiling
+## Building
 
 Once the toolchain is set up in the current path, the project can be built with
 
@@ -31,3 +31,15 @@ idf.py build
 ```
 
 That will create vesc_express.bin in the build directory, which can be used with the bootloader in VESC Tool. If the ESP32c3 does not come with firmware preinstalled, the USB-port can be used for flashing firmware using the built-in bootloader. That also requires bootloader.bin and partition-table.bin which also can be found in the build directory. This can be done from VESC Tool or using idf.py.
+
+### Custom Hardware Targets
+
+If you wish to build the project with custom hardware config files you have two options:
+1. Add the hardware files to the "**main/hwconf**" directory.
+2. Set the `HW_SRC` and `HW_HEADER` environment variables.
+
+For option 1. you could for instance add you're two files `hw_my_device.c` and `hw_my_device.h` into "**main/hw_conf**", and then edit the `HW_SOURCE` and `HW_HEADER` macro definitions in "**main/conf_general.h**" to the names of your new files. This method is ideal if you may want to contribute back these hardware configurations to the vesc_express repository!
+
+Option 2. is instead better if you have hardware configuration files in a directory which is outside the vesc_express source tree. You would then, for instance, set the environment variables `HW_SRC=/my/path/to/hw_my_device.c` and `HW_HEADER=/my/path/to/hw_my_device.h` when running `idf.py build`.
+
+**Note:** If you ever change the environment variables, or if when you first start using them, you need to first run `idf.py reconfigure` before building (with the environment variables still set of course!), as the build system unfortunately can't automatically detect this change. Running `idf.py fullclean` has the same effect as this forces cmake to rebuild the build configurations.

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -113,3 +113,19 @@ set(COMPONENT_ADD_INCLUDEDIRS
 )
 
 register_component()
+
+if((DEFINED ENV{HW_SRC}) OR (DEFINED ENV{HW_HEADER}))
+    if(NOT DEFINED ENV{HW_SRC})
+        message(FATAL_ERROR "HW_SRC not defined while HW_HEADER is set. You must either set both or none.")
+    endif()
+    if(NOT DEFINED ENV{HW_HEADER})
+        message(FATAL_ERROR "HW_HEADER not defined while HW_SRC is set. You must either set both or none.")
+    endif()
+    
+    message(STATUS "Setting HW_SOURCE=\"$ENV{HW_SRC}\" and HW_HEADER=\"$ENV{HW_HEADER}\" definitions")
+    
+    add_compile_definitions(
+        HW_SOURCE=\"$ENV{HW_SRC}\"
+        HW_HEADER=\"$ENV{HW_HEADER}\"
+    )
+endif()


### PR DESCRIPTION
This PR now only adds the `HW_SOURCE` and `HW_HEADER` macro definitions to vesc_express's source files. This means that the ESP IDF source files don't need to be rebuilt if you change those environment variables.

Also added a section to the README with instructions for how to build for custom hardware, with a note about how you need to run `idf.py reconfigure` if you change any of the hwconf environment variables.

I also fixed what I think was a mistake: I renaming the "Compilation" section to "Building". Please correct me if the name was intentional!