### PR TITLE
Feature/sd mount error reporting

### DIFF
--- a/main/lbm_vesc_utils.c
+++ b/main/lbm_vesc_utils.c
@@ -1,5 +1,6 @@
 /*
 	Copyright 2023 Rasmus Söderhielm    rasmus.soderhielm@gmail.com
+	          2024 Joakim Lundborg  	joakim.lundborg@gmail.com
 
 	This file is part of the VESC firmware.
 
@@ -137,4 +138,10 @@ bool f_pack_array(lbm_flat_value_t *result, void *data, size_t size) {
 	}
 
 	return true;
+}
+
+void lbm_set_esp_error_reason(esp_err_t res) {
+	static char ebuf[64];
+	sprintf(ebuf, "%s: %d", esp_err_to_name(res), res);
+	lbm_set_error_reason(ebuf);
 }

--- a/main/lbm_vesc_utils.h
+++ b/main/lbm_vesc_utils.h
@@ -199,3 +199,10 @@ bool lbm_check_argn_least(lbm_uint argn, lbm_uint n_min);
  * @return If necessary allocations were successfull. 
 */
 bool f_pack_array(lbm_flat_value_t *result, void *data, size_t size);
+
+/**
+ * Set LBM Error reason based on the ESP error code.
+ *  
+ * @param res The ESP error code to set as the error reason.
+*/
+void lbm_set_esp_error_reason(esp_err_t res);

--- a/main/lispif_vesc_extensions.c
+++ b/main/lispif_vesc_extensions.c
@@ -3501,9 +3501,14 @@ static lbm_value ext_f_connect(lbm_value *args, lbm_uint argn) {
 		return ENC_SYM_TERROR;
 	}
 
-	bool res = log_mount_card(pin_mosi, pin_miso, pin_sck, pin_cs, spi_speed);
+	esp_err_t res = log_mount_card(pin_mosi, pin_miso, pin_sck, pin_cs, spi_speed);
 
-	return res ? ENC_SYM_TRUE : ENC_SYM_NIL;
+	if (res == ESP_OK) {
+		return ENC_SYM_TRUE;
+	} else {
+		lbm_set_esp_error_reason(res);
+		return ENC_SYM_EERROR;
+	}
 }
 
 // (f-connect-nand pin-mosi pin-miso pin-sck pin-cs optSpiSpeed) -> t or nil

--- a/main/log.c
+++ b/main/log.c
@@ -267,7 +267,7 @@ static void log_task(void *arg) {
 	}
 }
 
-bool log_mount_card(int pin_mosi, int pin_miso, int pin_sck, int pin_cs, int freq) {
+esp_err_t log_mount_card(int pin_mosi, int pin_miso, int pin_sck, int pin_cs, int freq) {
 	esp_err_t ret;
 
 	esp_vfs_fat_sdmmc_mount_config_t mount_config = {
@@ -288,10 +288,10 @@ bool log_mount_card(int pin_mosi, int pin_miso, int pin_sck, int pin_cs, int fre
 	};
 
 	log_unmount_card();
-
+	
 	ret = spi_bus_initialize(m_host.slot, &bus_cfg, SDSPI_DEFAULT_DMA);
 	if (ret != ESP_OK) {
-		return false;
+		return ret;
 	}
 
 	sdspi_device_config_t slot_config = SDSPI_DEVICE_CONFIG_DEFAULT();
@@ -299,13 +299,7 @@ bool log_mount_card(int pin_mosi, int pin_miso, int pin_sck, int pin_cs, int fre
 	slot_config.host_id = m_host.slot;
 
 	file_basepath = "/sdcard/";
-	ret = esp_vfs_fat_sdspi_mount("/sdcard", &m_host, &slot_config, &mount_config, &m_card);
-
-	if (ret != ESP_OK) {
-		return false;
-	}
-
-	return true;
+	return esp_vfs_fat_sdspi_mount("/sdcard", &m_host, &slot_config, &mount_config, &m_card);
 }
 
 void log_unmount_card(void) {

--- a/main/log.h
+++ b/main/log.h
@@ -27,7 +27,7 @@
 
 // Functions
 bool log_init(void);
-bool log_mount_card(int pin_mosi, int pin_miso, int pin_sck, int pin_cs, int freq);
+esp_err_t log_mount_card(int pin_mosi, int pin_miso, int pin_sck, int pin_cs, int freq);
 void log_unmount_card(void);
 bool log_mount_nand_flash(int pin_mosi, int pin_miso, int pin_sck, int pin_cs, int freq);
 void log_unmount_nand_flash(void);

--- a/sdkconfig
+++ b/sdkconfig
@@ -741,7 +741,7 @@ CONFIG_ESP_COEX_SW_COEXIST_ENABLE=y
 #
 # Common ESP-related
 #
-# CONFIG_ESP_ERR_TO_NAME_LOOKUP is not set
+CONFIG_ESP_ERR_TO_NAME_LOOKUP=y
 # end of Common ESP-related
 
 #


### PR DESCRIPTION
This adds error reporting to SD mount functions, so the actual error can be inspected from lbm. 

To get the error codes from ESP SDK translated to strings, we would need to include them, this is about 8k. 

This change is also slightly API-incpompatible because (f-connect) will now raise EERROR if the mounting fails instead of returning nil. 

Example invocation of f-connect when SD card is not present:
![bild](https://github.com/user-attachments/assets/ab0510eb-db71-487e-a369-e3350dbcab87)
