### PR TITLE
Add v-cell-min and v-cell-max to lisp bms-config options

### DIFF
--- a/main/bms.c
+++ b/main/bms.c
@@ -87,6 +87,8 @@ bool bms_process_can_frame(uint32_t can_id, uint8_t *data8, int len, bool is_ext
 				m_values.soc = msg.soc;
 				m_values.soh = msg.soh;
 				m_values.temp_max_cell = msg.t_cell_max;
+				m_values.v_cell_min = msg.v_cell_min;
+				m_values.v_cell_max = msg.v_cell_max;
 				m_values.is_charging = msg.is_charging ? 1 : 0;
 				m_values.is_balancing = msg.is_balancing ? 1 : 0;
 				m_values.is_charge_allowed = msg.is_charge_allowed ? 1 : 0;
@@ -475,8 +477,8 @@ void bms_send_status_can(void) {
 	 * [RSV     RSV     RSV     RSV     RSV     CHG_OK  IS_BAL  IS_CHG  ]
 	 */
 	send_index = 0;
-	buffer_append_float16(buffer, -1.0, 1e3, &send_index);
-	buffer_append_float16(buffer, -1.0, 1e3, &send_index);
+	buffer_append_float16(buffer, (float_t)m_values.v_cell_min, 1e3, &send_index);
+	buffer_append_float16(buffer, (float_t)m_values.v_cell_max, 1e3, &send_index);
 	buffer[send_index++] = (uint8_t)(m_values.soc * 255.0);
 	buffer[send_index++] = (uint8_t)(m_values.soh * 255.0);
 	buffer[send_index++] = (int8_t)m_values.temp_max_cell;

--- a/main/datatypes.h
+++ b/main/datatypes.h
@@ -44,6 +44,8 @@ typedef struct {
 	float hum;
 	float pressure;
 	float temp_max_cell;
+	float v_cell_min;
+	float v_cell_max;
 	float soc;
 	float soh;
 	int can_id;

--- a/main/lispif_vesc_extensions.c
+++ b/main/lispif_vesc_extensions.c
@@ -100,6 +100,8 @@ typedef struct {
 	lbm_uint hum;
 	lbm_uint pres;
 	lbm_uint temp_max_cell;
+	lbm_uint v_cell_min;
+	lbm_uint v_cell_max;
 	lbm_uint soc;
 	lbm_uint soh;
 	lbm_uint can_id;
@@ -198,6 +200,10 @@ static bool compare_symbol(lbm_uint sym, lbm_uint *comp) {
 			lbm_add_symbol_const("bms-pres", comp);
 		} else if (comp == &syms_vesc.temp_max_cell) {
 			lbm_add_symbol_const("bms-temp-cell-max", comp);
+		} else if (comp == &syms_vesc.v_cell_min) {
+			lbm_add_symbol_const("bms-v-cell-min", comp);
+		} else if (comp == &syms_vesc.v_cell_max) {
+			lbm_add_symbol_const("bms-v-cell-max", comp);
 		} else if (comp == &syms_vesc.soc) {
 			lbm_add_symbol_const("bms-soc", comp);
 		} else if (comp == &syms_vesc.soh) {
@@ -534,6 +540,10 @@ static lbm_value get_set_bms_val(bool set, lbm_value *args, lbm_uint argn) {
 		res = get_or_set_float(set, &val->pressure, &set_arg);
 	} else if (compare_symbol(name, &syms_vesc.temp_max_cell)) {
 		res = get_or_set_float(set, &val->temp_max_cell, &set_arg);
+	} else if (compare_symbol(name, &syms_vesc.v_cell_min)) {
+		res = get_or_set_float(set, &val->v_cell_min, &set_arg);
+	} else if (compare_symbol(name, &syms_vesc.v_cell_max)) {
+		res = get_or_set_float(set, &val->v_cell_max, &set_arg);
 	} else if (compare_symbol(name, &syms_vesc.soc)) {
 		res = get_or_set_float(set, &val->soc, &set_arg);
 	} else if (compare_symbol(name, &syms_vesc.soh)) {


### PR DESCRIPTION
Add 'bms-v-cell-min and  'bms-v-cell-max to lisp. Fixed bms_send_status can so it will send m_values.v_cell_min and m_values.v_cell_max as opposed to hardcoded -1.0.