### PR TITLE
Docker container for build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:latest
+
+# Step 1. Install Prerequisites
+RUN : \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        --no-install-recommends \
+        git wget flex bison gperf python3 python3-pip python3-venv cmake ninja-build ccache libffi-dev libssl-dev dfu-util libusb-1.0-0 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && :
+
+# Step 2. Get ESP-IDF v5.2.2
+RUN mkdir -p /root/esp/
+RUN git clone -b v5.2.2 --recursive https://github.com/espressif/esp-idf.git /root/esp/esp-idf-v5.2.2
+
+# Step 3. Set up the Tools
+RUN /root/esp/esp-idf-v5.2.2/install.sh esp32c3
+
+# Step 4. Prepare the build Environment
+RUN echo ". /root/esp/esp-idf-v5.2.2/export.sh" > /root/.bashrc

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,42 @@
+# VESC Express build container
+This is a docker based environment to build your vesc express.
+
+The docker container contains the toolchain and the ESP release 5.2.2 that you need to build vesc express.
+
+## Make the docker image
+Using the Dockerfile in this folder you can make an image
+```
+sudo docker build -t esp-builder:5.2.2 .
+```
+This will take some time and build a quite large image (~4.1GB)
+
+## Spin up a container
+You can then make a container of this image using either the command:
+```
+sudo docker run -it -v ~/vesc:/home/vesc esp-builder:5.2.2 bash
+```
+You are now inside the container
+
+(Alternatively, use docker-compose or make a Portainer stack)
+
+## Clone source code and build
+While inside the container, clone the version of the vesc express source you want.
+
+Forexample the main branch from vedderb (the official version):
+```
+cd /home/vesc
+git clone https://github.com/vedderb/vesc_express.git
+```
+You will now have a copy of the vesc express source code. 
+
+If you want to do any changes to the code you can do that now. Since the `/home/vesc` folder inside the container is shared with the host operating system, so you can do the changes both on the host and in the container.
+
+To build it simply type the following inside the `vesc_express` folder
+```
+idf.py build
+```
+The build process will take some time, and create the bin files that you will use to flash the ESP. Look inside the `build` folder for `vesc_express.bin` 
+
+`bootloader.bin` is inside `build/bootloader`
+
+`partition-table.bin` is inside `build/partition_table`

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  app:
+    image: esp-builder:5.2.2
+    container_name: vesc_express_builder
+    tty: true
+    volumes:
+      - /home/[username]/vesc:/home/vesc


### PR DESCRIPTION
I made a docker image with the toolchain and the ESP release 5.2.2 and used it to build vesc_express in a container. 
Nice to have everything in a closed environment so you don't clutter up you main system. This could probably be used in WSL as well to build this on a Windows machine.

Thought I'd share my setup