### PR TITLE
feat: Add `wifi-connect-last` and `'no-wait` flag; Fix misc wifi extension problems 

### DIFF
--- a/main/comm_wifi.c
+++ b/main/comm_wifi.c
@@ -54,6 +54,7 @@ static bool wifi_reconnect_disabled = true;
 static bool wifi_auto_reconnect = true;
 static WIFI_MODE wifi_mode = WIFI_MODE_DISABLED;
 static volatile bool wifi_config_changed = false;
+// The currently applied wifi config
 static wifi_config_t wifi_config = {0};
 
 static comm_wifi_event_cb_t event_listener = NULL;
@@ -531,9 +532,10 @@ void comm_wifi_init(void) {
 		esp_wifi_set_config(WIFI_IF_STA, &wifi_config);
 
 		// Enable FTM responder
-		esp_wifi_get_config(WIFI_IF_AP, &wifi_config);
-		wifi_config.ap.ftm_responder = true;
-		esp_wifi_set_config(WIFI_IF_AP, &wifi_config);
+		wifi_config_t ap_wifi_config;
+		esp_wifi_get_config(WIFI_IF_AP, &ap_wifi_config);
+		ap_wifi_config.ap.ftm_responder = true;
+		esp_wifi_set_config(WIFI_IF_AP, &ap_wifi_config);
 
 		wifi_reconnect_disabled = false;
 	}
@@ -620,17 +622,25 @@ bool comm_wifi_change_network(const char *ssid, const char *password) {
 	memcpy(wifi_config.sta.password, password, password_len);
 	wifi_config.sta.password[password_len] = '\0';
 
+	STORED_LOGF("Changing network, ssid: '%s', password: '%s'", ssid, password);
+	
+	return comm_wifi_reconnect_network();
+}
+
+bool comm_wifi_reconnect_network() {
+	if (wifi_mode != WIFI_MODE_STATION) {
+		return false;
+	}
+	
 	wifi_config_changed = true;
-	wifi_reconnect_disabled       = false;
+	wifi_reconnect_disabled = false;
 
 	{
+		STORED_LOGF("Reconnecting to configured network, ssid: '%s', password: '%s'", wifi_config.sta.ssid, wifi_config.sta.password);
 		esp_err_t result = esp_wifi_set_config(WIFI_IF_STA, &wifi_config);
 		if (result == ESP_ERR_WIFI_PASSWORD) {
-			STORED_LOGF(
-				"incorrect wifi password, ssid: %p, password: %p", ssid,
-				password
-			);
-			STORED_LOGF("ssid: '%s', password: '%s'", ssid, password);
+			STORED_LOGF("incorrect wifi password");
+			
 			// TODO: Report incorrect password correctly. (Is incorrect password
 			// even ever reported here?)
 			return false;

--- a/main/comm_wifi.h
+++ b/main/comm_wifi.h
@@ -84,6 +84,19 @@ void comm_wifi_disconnect(void);
 bool comm_wifi_change_network(const char *ssid, const char *password);
 
 /**
+ * Disconnect and reconnect from the latest configured WIFI network.
+ * 
+ * This will close all existing TCP sockets!
+ * 
+ * The process has finshed when the IP_EVENT_STA_GOT_IP has fired in the event
+ * listener.
+ * 
+ * @return If the wifi_mode isn't WIFI_MODE_STATION, false is returned and this
+ * function is a no-op. Otherwise if false is returned some ESP function failed.
+*/
+bool comm_wifi_reconnect_network();
+
+/**
  * Disconnect from the currently connected network, without automatically
  * reconnecting afterwards.
  * 

--- a/main/wifi/lispif_wifi_extensions.c
+++ b/main/wifi/lispif_wifi_extensions.c
@@ -514,6 +514,7 @@ static lbm_value ext_wifi_connect(lbm_value *args, lbm_uint argn) {
 
 	bool result = comm_wifi_change_network(ssid, password);
 	if (!result) {
+		is_waiting = false;
 		return ENC_SYM_NIL;
 	}
 

--- a/main/wifi/lispif_wifi_extensions.c
+++ b/main/wifi/lispif_wifi_extensions.c
@@ -74,6 +74,8 @@ static lbm_uint symbol_connecting     = 0;
 static lbm_uint symbol_disconnected   = 0;
 static lbm_uint symbol_socket_error   = 0;
 static lbm_uint symbol_connect_error  = 0;
+static lbm_uint symbol_wait           = 0;
+static lbm_uint symbol_no_wait        = 0;
 
 static volatile bool init_done = false;
 
@@ -87,7 +89,8 @@ static bool register_symbols(void) {
 	res = res && lbm_add_symbol_const("connecting", &symbol_connecting);
 	res = res && lbm_add_symbol_const("disconnected", &symbol_disconnected);
 	res = res && lbm_add_symbol_const("socket-error", &symbol_socket_error);
-	res = res && lbm_add_symbol_const("connect-error", &symbol_connect_error);
+	res = res && lbm_add_symbol_const("wait", &symbol_wait);
+	res = res && lbm_add_symbol_const("no-wait", &symbol_no_wait);
 
 	return res;
 }
@@ -404,6 +407,10 @@ static void event_listener(
  * networks.
  */
 static lbm_value ext_wifi_scan_networks(lbm_value *args, lbm_uint argn) {
+	if (!wifi_precheck(PRECHECK_NOT_WAITING | PRECHECK_MODE_STATION_ONLY)) {
+		return ENC_SYM_EERROR;
+	}
+	
 	uint32_t scan_time = 120;
 	if (argn >= 1) {
 		scan_time = (uint32_t)(lbm_dec_as_float(args[0]) * 1000);
@@ -458,7 +465,7 @@ static lbm_value ext_wifi_scan_networks(lbm_value *args, lbm_uint argn) {
 }
 
 /**
- * signature: (wifi-connect ssid:string password:string|nil) -> bool
+ * signature: (wifi-connect ssid:string password:string|nil [wait-flag:'wait|'no-wait]) -> bool
  *
  * Connect to the specified wifi network.
  *
@@ -467,6 +474,8 @@ static lbm_value ext_wifi_scan_networks(lbm_value *args, lbm_uint argn) {
  * @param password The network's password. Pass nil if the network
  * doesn't have a password. Must not be longer than 63 characters
  * (excluding the null byte).
+ * @param wait-flag [optional] If the extension should wait for the connection
+ * result. (default: 'wait)
  * @return True if the connection was successfull (the connection is
  * then ready for opening tcp sockets at this point). Otherwise
  * 'wrong_password is returned if the password or ssid was incorrect
@@ -479,8 +488,8 @@ static lbm_value ext_wifi_connect(lbm_value *args, lbm_uint argn) {
 	if (!wifi_precheck(PRECHECK_NOT_WAITING | PRECHECK_MODE_STATION_ONLY)) {
 		return ENC_SYM_EERROR;
 	}
-
-	LBM_CHECK_ARGN(2);
+	
+	LBM_CHECK_ARGN_RANGE(2, 3)
 
 	if (!lbm_is_array_r(args[0])
 		|| !(lbm_is_array_r(args[1]) || lbm_is_symbol_nil(args[1]))) {
@@ -507,19 +516,86 @@ static lbm_value ext_wifi_connect(lbm_value *args, lbm_uint argn) {
 		lbm_set_error_reason(error_esp_too_long_password);
 		return ENC_SYM_EERROR;
 	}
-
-	waiting_cid = lbm_get_current_cid();
-	waiting_op  = WAITING_OP_CHANGE_NETWORK;
-	is_waiting  = true;
-
-	bool result = comm_wifi_change_network(ssid, password);
-	if (!result) {
-		is_waiting = false;
-		return ENC_SYM_NIL;
+	
+	bool should_wait = true;
+	if (argn >= 3) {
+		if (!lbm_is_symbol(args[2])) {
+			lbm_set_error_suspect(args[2]);
+			return ENC_SYM_TERROR;
+		}
+		lbm_uint symbol = lbm_dec_sym(args[2]);
+		if (symbol == symbol_wait) {
+			should_wait = true;
+		} else if (symbol == symbol_no_wait) {
+			should_wait = false;
+		} else {
+			lbm_set_error_suspect(args[2]);
+			return ENC_SYM_TERROR;
+		}
 	}
+	
+	if (should_wait) {		
+		waiting_cid = lbm_get_current_cid();
+		waiting_op  = WAITING_OP_CHANGE_NETWORK;
+		is_waiting  = true;
+		
+		bool result = comm_wifi_change_network(ssid, password);
+		
+		if (!result) {
+			is_waiting = false;
+			return ENC_SYM_NIL;
+		}
+		
+		lbm_block_ctx_from_extension();
+		return ENC_SYM_NIL;
+	} else {
+		bool result = comm_wifi_change_network(ssid, password);
+		return lbm_enc_bool(result);
+	}
+}
 
-	lbm_block_ctx_from_extension();
-	return ENC_SYM_NIL;
+static lbm_value ext_wifi_connect_last(lbm_value *args, lbm_uint argn) {
+	if (!wifi_precheck(PRECHECK_NOT_WAITING | PRECHECK_MODE_STATION_ONLY)) {
+		return ENC_SYM_EERROR;
+	}
+	
+	LBM_CHECK_ARGN_RANGE(0, 1)
+	
+	bool should_wait = true;
+	if (argn >= 1) {
+		if (!lbm_is_symbol(args[0])) {
+			lbm_set_error_suspect(args[0]);
+			return ENC_SYM_TERROR;
+		}
+		lbm_uint symbol = lbm_dec_sym(args[0]);
+		if (symbol == symbol_wait) {
+			should_wait = true;
+		} else if (symbol == symbol_no_wait) {
+			should_wait = false;
+		} else {
+			lbm_set_error_suspect(args[0]);
+			return ENC_SYM_TERROR;
+		}
+	}
+	
+	if (should_wait) {
+		waiting_cid = lbm_get_current_cid();
+		waiting_op  = WAITING_OP_CHANGE_NETWORK;
+		is_waiting  = true;
+		
+		bool result = comm_wifi_reconnect_network();
+		
+		if (!result) {
+			is_waiting = false;
+			return ENC_SYM_NIL;
+		} 
+		
+		lbm_block_ctx_from_extension();
+		return ENC_SYM_NIL;
+	} else {
+		bool result = comm_wifi_reconnect_network();
+		return lbm_enc_bool(result);
+	}
 }
 
 /**
@@ -783,7 +859,7 @@ static bool custom_socket_valid(int socket) {
  * @return todo
  */
 static lbm_value ext_tcp_connect(lbm_value *args, lbm_uint argn) {
-	if (!wifi_precheck(PRECHECK_NOT_WAITING)) {
+	if (!wifi_precheck(PRECHECK_MODE_STATION_ONLY)) {
 		return ENC_SYM_EERROR;
 	}
 
@@ -886,7 +962,7 @@ static lbm_value ext_tcp_connect(lbm_value *args, lbm_uint argn) {
  * (@todo: be more precise).
  */
 static lbm_value ext_tcp_close(lbm_value *args, lbm_uint argn) {
-	if (!wifi_precheck(PRECHECK_NOT_WAITING)) {
+	if (!wifi_precheck(PRECHECK_MODE_STATION_ONLY)) {
 		return ENC_SYM_EERROR;
 	}
 
@@ -944,7 +1020,7 @@ static lbm_value ext_tcp_close(lbm_value *args, lbm_uint argn) {
  * internal process, that shouldn't happen).
  */
 static lbm_value ext_tcp_status(lbm_value *args, lbm_uint argn) {
-	if (!wifi_precheck(PRECHECK_NOT_WAITING)) {
+	if (!wifi_precheck(PRECHECK_MODE_STATION_ONLY)) {
 		return ENC_SYM_EERROR;
 	}
 
@@ -1004,7 +1080,7 @@ static lbm_value ext_tcp_status(lbm_value *args, lbm_uint argn) {
  * @todo: Document this
  */
 static lbm_value ext_tcp_send(lbm_value *args, lbm_uint argn) {
-	if (!wifi_precheck(PRECHECK_NOT_WAITING)) {
+	if (!wifi_precheck(PRECHECK_MODE_STATION_ONLY)) {
 		return ENC_SYM_EERROR;
 	}
 
@@ -1237,7 +1313,7 @@ recv_cleanup:
  * writing this) network error occurred.
  */
 static lbm_value ext_tcp_recv(lbm_value *args, lbm_uint argn) {
-	if (!wifi_precheck(PRECHECK_NOT_WAITING)) {
+	if (!wifi_precheck(PRECHECK_MODE_STATION_ONLY)) {
 		return ENC_SYM_EERROR;
 	}
 
@@ -1378,7 +1454,7 @@ static lbm_value ext_tcp_recv(lbm_value *args, lbm_uint argn) {
  * this) network error occurred.
  */
 static lbm_value ext_tcp_recv_to_char(lbm_value *args, lbm_uint argn) {
-	if (!wifi_precheck(PRECHECK_MODE_STATION_ONLY|PRECHECK_NOT_WAITING)) {
+	if (!wifi_precheck(PRECHECK_MODE_STATION_ONLY)) {
 		return ENC_SYM_EERROR;
 	}
 
@@ -1478,6 +1554,7 @@ void lispif_load_wifi_extensions(void) {
 
 	lbm_add_extension("wifi-scan-networks", ext_wifi_scan_networks);
 	lbm_add_extension("wifi-connect", ext_wifi_connect);
+	lbm_add_extension("wifi-connect-last", ext_wifi_connect_last);
 	lbm_add_extension("wifi-disconnect", ext_wifi_disconnect);
 	lbm_add_extension("wifi-status", ext_wifi_status);
 	lbm_add_extension("wifi-max-tx-power", ext_wifi_max_tx_power);


### PR DESCRIPTION
This PR fixes a bug in `wifi-connect` (the first commit). It also adds two new features:

1. Adds the new `wifi-connect-last` wifi extension which tries to connect to the network from the last call to `wifi-connect`---if it has been called previously---or from the VESC config.
2. Also adds the new `'no-wait` flag which you can pass to `wifi-connect` and `wifi-connect-last`. This makes them return immediately, without blocking until the result of the connection is known.

The target usecase for both of these features is to be able to re-enable auto-reconnection after having called `wifi-disconnect`, but only to disconnect temporarily e.g. to be able to call `wifi-scan-networks` (which requires that we aren't trying to connect to a network currently). In this case you may not care about knowing how the connection went, since you just want it to continue to attempt reconnecting if not connected as it did before.

I also updated the precheck conditions to make them more useful. The important change was that the tcp extensions are no longer blocked by the wifi extentions being called by another thread. There wasn't really a reason to have that restriction in the first case, since they are either not blocking, or use separate C-threads, meaning they won't override any stored context IDs.

The documentation has been updated to match these changes. I also added explicit notes to the extensions that can't be called asynchronously.
