### PR TITLE
Fix truncation of any hw name containing h in cmakelists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ endforeach()
 if(DEFINED HW_NAME AND DEFINED HW_TARGET AND DEFINED HW_FILE_NAME)
     # Get file name without extension
     string(REGEX MATCH "([^/]+)$" HW_FILE ${HW_FILE_NAME})
-    string(REGEX REPLACE ".h" "" HW_FILE ${HW_FILE})
+    string(REPLACE ".h" "" HW_FILE ${HW_FILE})
 
     # IMPORTANT: Set IDF_TARGET before including project.cmake
     if(NOT DEFINED IDF_TARGET)


### PR DESCRIPTION
Fix loss of hw name when running regex in cmakelists

<img width="425" height="93" alt="Screenshot 2026-02-24 at 9 08 41 AM" src="https://github.com/user-attachments/assets/c429742d-3928-44c0-99b4-ea8a811e6862" />
<img width="425" height="93" alt="Screenshot 2026-02-24 at 9 08 41 AM" src="https://github.com/user-attachments/assets/c429742d-3928-44c0-99b4-ea8a811e6862" />
<img width="518" height="21" alt="Screenshot 2026-02-24 at 9 08 48 AM" src="https://github.com/user-attachments/assets/5f393561-75ee-40ed-b73f-ed97133d3d35" />
<img width="518" height="21" alt="Screenshot 2026-02-24 at 9 08 48 AM" src="https://github.com/user-attachments/assets/5f393561-75ee-40ed-b73f-ed97133d3d35" />
<img width="1151" height="320" alt="Screenshot 2026-02-24 at 9 10 05 AM" src="https://github.com/user-attachments/assets/b64a0cd5-4b22-4476-a8d8-2a252f3e51e0" />
<img width="1151" height="320" alt="Screenshot 2026-02-24 at 9 10 05 AM" src="https://github.com/user-attachments/assets/b64a0cd5-4b22-4476-a8d8-2a252f3e51e0" />

