### PR TITLE
Fix BMS aggregate replies and Lisp sleep handling

### DIFF
--- a/main/bms.c
+++ b/main/bms.c
@@ -40,11 +40,24 @@ static volatile bms_values m_values;
 static volatile bms_soc_soh_temp_stat m_stat_temp_max;
 static volatile bms_soc_soh_temp_stat m_stat_soc_min;
 static volatile bms_soc_soh_temp_stat m_stat_soc_max;
+static SemaphoreHandle_t reply_mutex;
+
+static int clamp_count(int count, int max) {
+	if (count < 0) {
+		return 0;
+	}
+
+	return count > max ? max : count;
+}
 
 // Function pointers
 static void(*cmd_handler)(COMM_PACKET_ID cmd, int param1, int param2) = 0;
 
 void bms_init(void) {
+	if (!reply_mutex) {
+		reply_mutex = xSemaphoreCreateMutex();
+	}
+
 	memset((void*)&m_values, 0, sizeof(m_values));
 	memset((void*)&m_stat_temp_max, 0, sizeof(m_stat_temp_max));
 	memset((void*)&m_stat_soc_min, 0, sizeof(m_stat_soc_min));
@@ -168,7 +181,7 @@ bool bms_process_can_frame(uint32_t can_id, uint8_t *data8, int len, bool is_ext
 				m_values.can_id = id;
 				m_values.update_time = xTaskGetTickCount();
 				unsigned int ofs = data8[ind++];
-				m_values.cell_num = data8[ind++];
+				m_values.cell_num = clamp_count(data8[ind++], BMS_MAX_CELLS);
 
 				while(ind < len) {
 					if (ofs >= (sizeof(m_values.v_cell) / sizeof(float))) {
@@ -211,7 +224,7 @@ bool bms_process_can_frame(uint32_t can_id, uint8_t *data8, int len, bool is_ext
 				m_values.can_id = id;
 				m_values.update_time = xTaskGetTickCount();
 				unsigned int ofs = data8[ind++];
-				m_values.temp_adc_num = data8[ind++];
+				m_values.temp_adc_num = clamp_count(data8[ind++], BMS_MAX_TEMPS);
 
 				while(ind < len) {
 					if (ofs >= (sizeof(m_values.temps_adc) / sizeof(float))) {
@@ -297,9 +310,16 @@ void bms_process_cmd(unsigned char *data, unsigned int len,
 	switch (packet_id) {
 	case COMM_BMS_GET_VALUES: {
 		int32_t ind = 0;
-		uint8_t send_buffer[256];
+		static uint8_t send_buffer[1024];
+
+		if (reply_mutex) {
+			xSemaphoreTake(reply_mutex, portMAX_DELAY);
+		}
 
 		send_buffer[ind++] = packet_id;
+
+		int cell_num = clamp_count(m_values.cell_num, BMS_MAX_CELLS);
+		int temp_adc_num = clamp_count(m_values.temp_adc_num, BMS_MAX_TEMPS);
 
 		buffer_append_float32(send_buffer, m_values.v_tot, 1e6, &ind);
 		buffer_append_float32(send_buffer, m_values.v_charge, 1e6, &ind);
@@ -309,19 +329,19 @@ void bms_process_cmd(unsigned char *data, unsigned int len,
 		buffer_append_float32(send_buffer, m_values.wh_cnt, 1e3, &ind);
 
 		// Cell voltages
-		send_buffer[ind++] = m_values.cell_num;
-		for (int i = 0;i < m_values.cell_num;i++) {
+		send_buffer[ind++] = cell_num;
+		for (int i = 0;i < cell_num;i++) {
 			buffer_append_float16(send_buffer, m_values.v_cell[i], 1e3, &ind);
 		}
 
 		// Balancing state
-		for (int i = 0;i < m_values.cell_num;i++) {
+		for (int i = 0;i < cell_num;i++) {
 			send_buffer[ind++] = m_values.bal_state[i];
 		}
 
 		// Temperatures
-		send_buffer[ind++] = m_values.temp_adc_num;
-		for (int i = 0;i < m_values.temp_adc_num;i++) {
+		send_buffer[ind++] = temp_adc_num;
+		for (int i = 0;i < temp_adc_num;i++) {
 			buffer_append_float16(send_buffer, m_values.temps_adc[i], 1e2, &ind);
 		}
 		buffer_append_float16(send_buffer, m_values.temp_ic, 1e2, &ind);
@@ -357,6 +377,10 @@ void bms_process_cmd(unsigned char *data, unsigned int len,
 		ind += strlen((char*)m_values.status) + 1;
 
 		reply_func(send_buffer, ind);
+
+		if (reply_mutex) {
+			xSemaphoreGive(reply_mutex);
+		}
 	} break;
 
 	default:
@@ -423,15 +447,12 @@ void bms_send_status_can(void) {
 	comm_can_transmit_eid(id | ((uint32_t)CAN_PACKET_BMS_AH_WH << 8), buffer, send_index);
 
 	int cell_now = 0;
-	int cell_max = m_values.cell_num;
-	if (cell_max > BMS_MAX_CELLS) {
-		cell_max = BMS_MAX_CELLS;
-	}
+	int cell_max = clamp_count(m_values.cell_num, BMS_MAX_CELLS);
 
 	while (cell_now < cell_max) {
 		send_index = 0;
 		buffer[send_index++] = cell_now;
-		buffer[send_index++] = m_values.cell_num;
+		buffer[send_index++] = cell_max;
 		if (cell_now < cell_max) {
 			buffer_append_float16(buffer, m_values.v_cell[cell_now++], 1e3, &send_index);
 		}
@@ -460,10 +481,7 @@ void bms_send_status_can(void) {
 	comm_can_transmit_eid(id | ((uint32_t)CAN_PACKET_BMS_BAL << 8), buffer, send_index);
 
 	int temp_now = 0;
-	int temp_max = m_values.temp_adc_num;
-	if (temp_max > BMS_MAX_TEMPS) {
-		temp_max = BMS_MAX_TEMPS;
-	}
+	int temp_max = clamp_count(m_values.temp_adc_num, BMS_MAX_TEMPS);
 
 	while (temp_now < temp_max) {
 		send_index = 0;
@@ -484,7 +502,7 @@ void bms_send_status_can(void) {
 	send_index = 0;
 	buffer_append_float16(buffer, m_values.temp_hum, 1e2, &send_index);
 	buffer_append_float16(buffer, m_values.hum, 1e2, &send_index);
-	buffer_append_float16(buffer, m_values.temp_ic, 1e2, &send_index); // Put IC temp here instead of making mew msg
+	buffer_append_float16(buffer, m_values.temp_ic, 1e2, &send_index); // Put IC temp here instead of adding a new message
 	comm_can_transmit_eid(id | ((uint32_t)CAN_PACKET_BMS_HUM << 8), buffer, send_index);
 
 	/*

--- a/main/datatypes.h
+++ b/main/datatypes.h
@@ -24,7 +24,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#define BMS_MAX_CELLS	50
+#define BMS_MAX_CELLS	255
 #define BMS_MAX_TEMPS	50
 #define BMS_STATUS_LEN	41
 

--- a/main/lispif_vesc_extensions.c
+++ b/main/lispif_vesc_extensions.c
@@ -3669,12 +3669,14 @@ static void sleep_disable_radios(void) {
 static void sleep_deinit_radios(void) {
 	sleep_disable_radios();
 
+#if !CONFIG_IDF_TARGET_ESP32P4
 	if (esp_bluedroid_get_status() == ESP_BLUEDROID_STATUS_INITIALIZED) {
 		esp_bluedroid_deinit();
 	}
 	if (esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_INITED) {
 		esp_bt_controller_deinit();
 	}
+#endif
 }
 
 static lbm_value ext_sleep_deep(lbm_value *args, lbm_uint argn) {

--- a/main/lispif_vesc_extensions.c
+++ b/main/lispif_vesc_extensions.c
@@ -3647,12 +3647,40 @@ static lbm_value ext_set_pos_time(lbm_value *args, lbm_uint argn) {
 	return ENC_SYM_TRUE;
 }
 
+// Disable radios before sleeping. Reversible; safe for light sleep where
+// execution resumes after wake and the BT/WiFi stacks must still be usable.
+static void sleep_disable_radios(void) {
+#if !CONFIG_IDF_TARGET_ESP32P4
+	esp_wifi_stop();
+
+	if (esp_bluedroid_get_status() == ESP_BLUEDROID_STATUS_ENABLED) {
+		esp_bluedroid_disable();
+	}
+
+	if (esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_ENABLED) {
+		esp_bt_controller_disable();
+	}
+#endif
+}
+
+// Full teardown for deep sleep only. The chip reboots on wake so deinit is
+// free; doing it here prevents BLE state corruption observed across many
+// 2h-cycle wakes (BMS freeze after weeks).
+static void sleep_deinit_radios(void) {
+	sleep_disable_radios();
+
+	if (esp_bluedroid_get_status() == ESP_BLUEDROID_STATUS_INITIALIZED) {
+		esp_bluedroid_deinit();
+	}
+	if (esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_INITED) {
+		esp_bt_controller_deinit();
+	}
+}
+
 static lbm_value ext_sleep_deep(lbm_value *args, lbm_uint argn) {
 	LBM_CHECK_ARGN_NUMBER(1);
 
-	#if !CONFIG_IDF_TARGET_ESP32P4
-	esp_wifi_stop();
-	#endif
+	sleep_deinit_radios();
 
 	float sleep_time = lbm_dec_as_float(args[0]);
 	if (sleep_time > 0) {
@@ -3670,9 +3698,10 @@ static lbm_value ext_sleep_deep(lbm_value *args, lbm_uint argn) {
 static lbm_value ext_sleep_light(lbm_value *args, lbm_uint argn) {
 	LBM_CHECK_ARGN_NUMBER(1);
 
-	#if !CONFIG_IDF_TARGET_ESP32P4
-	esp_wifi_stop();
-	#endif
+	// Light sleep returns to the caller with stacks intact, so use the
+	// reversible disable path; a deinit here would leave the unit
+	// permanently without BT/WiFi until reboot.
+	sleep_disable_radios();
 
 	float sleep_time = lbm_dec_as_float(args[0]);
 	if (sleep_time > 0) {

--- a/main/lispif_vesc_extensions.c
+++ b/main/lispif_vesc_extensions.c
@@ -3656,7 +3656,10 @@ static lbm_value ext_sleep_deep(lbm_value *args, lbm_uint argn) {
 
 	float sleep_time = lbm_dec_as_float(args[0]);
 	if (sleep_time > 0) {
-		esp_sleep_enable_timer_wakeup((uint32_t)(sleep_time * 1.0e6));
+		// esp_sleep_enable_timer_wakeup takes microseconds. With uint32_t the
+		// limit is ~4294 s (71.6 min); longer sleeps wrap modulo 2^32, so
+		// 2 h becomes ~2905 s (~48.4 min). Use uint64_t for multi-hour sleeps.
+		esp_sleep_enable_timer_wakeup((uint64_t)(sleep_time * 1.0e6));
 	}
 
 	esp_deep_sleep_start();
@@ -3673,7 +3676,7 @@ static lbm_value ext_sleep_light(lbm_value *args, lbm_uint argn) {
 
 	float sleep_time = lbm_dec_as_float(args[0]);
 	if (sleep_time > 0) {
-		esp_sleep_enable_timer_wakeup((uint32_t)(sleep_time * 1.0e6));
+		esp_sleep_enable_timer_wakeup((uint64_t)(sleep_time * 1.0e6));
 	}
 
 	esp_light_sleep_start();


### PR DESCRIPTION
This PR contains a small set of reliability fixes that are independent of new hardware targets.

Changes:
- Fixes `COMM_BMS_GET_VALUES` reply capacity for larger aggregate BMS payloads.
- Clamps received and transmitted BMS cell/temperature counts before indexing local arrays.
- Fixes `uint32_t` wraparound in Lisp sleep timer wakeups for long sleep intervals.
- Splits light/deep sleep handling and tears down radios before sleep to reduce long-cycle sleep/wake failures.

Motivation:
These fixes are useful for existing hardware targets and do not depend on JetFleet-specific hardware or ESP-IDF v6 migration work.

Testing:
- Split from the tested `cleanup/upstream-ready` branch.
- Runtime-tested on BMS hardware through repeated sleep/wake cycles.

