### PR TITLE
Add hardware CAN hooks and slave-mode toggles

### DIFF
--- a/main/comm_can.c
+++ b/main/comm_can.c
@@ -67,7 +67,11 @@ static psw_status psw_stat[CAN_STATUS_MSGS_TO_STORE];
 
 static twai_timing_config_t t_config = TWAI_TIMING_CONFIG_500KBITS();
 static const twai_filter_config_t f_config = TWAI_FILTER_CONFIG_ACCEPT_ALL();
+#if HW_CAN_NO_ACK_MODE
+static twai_general_config_t g_config = TWAI_GENERAL_CONFIG_DEFAULT(0, 0, TWAI_MODE_NO_ACK);
+#else
 static twai_general_config_t g_config = TWAI_GENERAL_CONFIG_DEFAULT(0, 0, TWAI_MODE_NORMAL);
+#endif
 
 static volatile bool init_done = false;
 static volatile bool sem_init_done = false;

--- a/main/comm_can.c
+++ b/main/comm_can.c
@@ -66,12 +66,19 @@ static psw_status psw_stat[CAN_STATUS_MSGS_TO_STORE];
 #define RXBUF_LEN					50
 
 static twai_timing_config_t t_config = TWAI_TIMING_CONFIG_500KBITS();
-static const twai_filter_config_t f_config = TWAI_FILTER_CONFIG_ACCEPT_ALL();
+static twai_filter_config_t f_config = TWAI_FILTER_CONFIG_ACCEPT_ALL();
 #if HW_CAN_NO_ACK_MODE
 static twai_general_config_t g_config = TWAI_GENERAL_CONFIG_DEFAULT(0, 0, TWAI_MODE_NO_ACK);
 #else
 static twai_general_config_t g_config = TWAI_GENERAL_CONFIG_DEFAULT(0, 0, TWAI_MODE_NORMAL);
 #endif
+
+static void update_filter(void) {
+	twai_filter_config_t hw_filter;
+	if (HW_CAN_FILTER_CONFIG(&hw_filter)) {
+		f_config = hw_filter;
+	}
+}
 
 static volatile bool init_done = false;
 static volatile bool sem_init_done = false;
@@ -635,6 +642,12 @@ static void process_task(void *arg) {
 
 			lispif_process_can(msg->identifier, msg->data, msg->data_length_code, msg->extd);
 
+			// Hardware-specific CAN hook (weak symbol, can be overridden)
+			extern void hw_can_rx_hook(uint32_t id, uint8_t *data, int len, bool is_ext) __attribute__((weak));
+			if (hw_can_rx_hook) {
+				hw_can_rx_hook(msg->identifier, msg->data, msg->data_length_code, msg->extd);
+			}
+
 			if (use_vesc_decoder) {
 				if (!bms_process_can_frame(msg->identifier, msg->data, msg->data_length_code, msg->extd)) {
 					if (msg->extd) {
@@ -858,6 +871,7 @@ void comm_can_start(int pin_tx, int pin_rx) {
 	}
 
 	update_baud(backup.config.can_baud_rate);
+	update_filter();
 
 	g_config.tx_queue_len = 20;
 	g_config.rx_queue_len = 20;
@@ -936,6 +950,7 @@ void comm_can_update_baudrate(int delay_msec) {
 	}
 
 	update_baud(backup.config.can_baud_rate);
+	update_filter();
 	twai_driver_install(&g_config, &t_config, &f_config);
 	twai_start();
 

--- a/main/commands.c
+++ b/main/commands.c
@@ -150,12 +150,14 @@ static void block_task(void *arg) {
 			int32_t ind = 0;
 			send_buffer[ind++] = COMM_PING_CAN;
 
+#if HW_CAN_PING_SCAN_ENABLED
 			for (uint8_t i = 0;i < 255;i++) {
 				HW_TYPE hw_type;
 				if (comm_can_ping(i, &hw_type)) {
 					send_buffer[ind++] = i;
 				}
 			}
+#endif
 
 			if (send_func_blocking) {
 				send_func_blocking(send_buffer, ind);

--- a/main/hwconf/hw.h
+++ b/main/hwconf/hw.h
@@ -73,6 +73,13 @@
 #define HW_CAN_PING_SCAN_ENABLED 1
 #endif
 
+// Set to 1 in a hwconf header to bring up TWAI in TWAI_MODE_NO_ACK instead of
+// TWAI_MODE_NORMAL. Useful for diagnostic builds that should not generate ACKs
+// on a live bus.
+#ifndef HW_CAN_NO_ACK_MODE
+#define HW_CAN_NO_ACK_MODE 0
+#endif
+
 #ifndef UART_NUM
 #define HW_NO_UART
 #define UART_NUM					0

--- a/main/hwconf/hw.h
+++ b/main/hwconf/hw.h
@@ -66,6 +66,13 @@
 #define LOGS_ENABLED 0
 #endif
 
+// Set to 0 in a hwconf header to skip the COMM_PING_CAN scan loop. Useful for
+// headless variants that share a bus with a master and should never respond to
+// or initiate VESC ping discovery.
+#ifndef HW_CAN_PING_SCAN_ENABLED
+#define HW_CAN_PING_SCAN_ENABLED 1
+#endif
+
 #ifndef UART_NUM
 #define HW_NO_UART
 #define UART_NUM					0

--- a/main/hwconf/hw.h
+++ b/main/hwconf/hw.h
@@ -80,6 +80,14 @@
 #define HW_CAN_NO_ACK_MODE 0
 #endif
 
+// Hardware-specific CAN acceptance filter hook. A hwconf header can override
+// this macro to forward to a function that fills a twai_filter_config_t and
+// returns true. The default expands to false, which the compiler eliminates
+// so no filter override is applied.
+#ifndef HW_CAN_FILTER_CONFIG
+#define HW_CAN_FILTER_CONFIG(cfg) ((void)(cfg), false)
+#endif
+
 #ifndef UART_NUM
 #define HW_NO_UART
 #define UART_NUM					0

--- a/main/main.c
+++ b/main/main.c
@@ -136,7 +136,7 @@ void app_main(void) {
 
 	vTaskDelay(1);
 
-	#if !CONFIG_IDF_TARGET_ESP32P4
+#if !CONFIG_IDF_TARGET_ESP32P4 && !defined(HW_IS_SLAVE)
 	switch (backup.config.ble_mode) {
 		case BLE_MODE_DISABLED: {
 			break;
@@ -155,7 +155,7 @@ void app_main(void) {
 	if (backup.config.wifi_mode != WIFI_MODE_DISABLED) {
 		comm_wifi_init();
 	}
-	#endif
+#endif
 
 	nmea_init();
 	log_init();
@@ -218,8 +218,10 @@ uint32_t main_calc_hw_crc(void) {
 
 void main_store_backup_data(void) {
 	nvs_handle_t my_handle;
+#ifndef HW_IS_SLAVE
 	backup.controller_id = backup.config.controller_id;
 	backup.can_baud_rate = backup.config.can_baud_rate;
+#endif
 	nvs_open("vesc", NVS_READWRITE, &my_handle);
 	nvs_set_blob(my_handle, "backup", (void*)&backup, sizeof(backup_data));
 	nvs_commit(my_handle);


### PR DESCRIPTION
This PR adds optional hardware configuration hooks used by headless and private-CAN hardware variants.

Changes:
- Adds `HW_CAN_PING_SCAN_ENABLED` to let hardware configs opt out of CAN ping scans.
- Adds `HW_CAN_NO_ACK_MODE` for hardware that needs CAN no-ack mode.
- Adds optional hardware CAN filter and RX hooks.
- Adds `HW_IS_SLAVE` for headless variants that should not initialize the full normal application role.

Motivation:
These are compile-time hooks with default behavior unchanged for existing hardware. They make it possible to support simpler/headless CAN devices without adding board-specific conditionals to common code.

Compatibility:
Existing hardware targets keep the previous behavior unless they define the new macros.

Testing:
- Split from the tested `cleanup/upstream-ready` branch.
- Tested with the JFBMS slave hardware variant that depends on these hooks.

