### PR TITLE
Fix ILI9488 color handling: correct RGB888 data order during SPI writes

### DIFF
--- a/main/display/disp_ili9488.c
+++ b/main/display/disp_ili9488.c
@@ -110,9 +110,10 @@ static void blast_indexed16(image_buffer_t *img, color_t *colors) {
 		int bit = (1 - (i & 0x01)) * 4; // bit position to access within byte
 		int color_ind = (data[byte] & (0x0F << bit)) >> bit; // extract 4 bit value.
 
-		uint16_t c = COLOR_TO_RGB888(colors[color_ind],	i % img->width, i / img->width);
-		hwspi_data_stream_write((uint8_t)c);
-		hwspi_data_stream_write((uint8_t)(c >> 8));
+        uint32_t c = COLOR_TO_RGB888(colors[color_ind], i % img->width, i / img->width);
+        hwspi_data_stream_write((uint8_t)(c >> 16));  // R
+        hwspi_data_stream_write((uint8_t)(c >> 8));   // G
+        hwspi_data_stream_write((uint8_t)(c >> 0));   // B
 	}
 
 	hwspi_data_stream_finish();


### PR DESCRIPTION
The `indexed16` color mode was broken when working with my screen on the i9488:

### Before this fix
#### indexed4
<img width="1280" height="750" alt="image" src="https://github.com/user-attachments/assets/b6fd9b55-fa76-4502-be74-82ccbb54f6bf" />

#### indexed16
<img width="1280" height="766" alt="image" src="https://github.com/user-attachments/assets/ef794c78-dd3a-4588-9267-7091356dde97" />

### After this fix
#### indexed16
<img width="1816" height="2308" alt="image" src="https://github.com/user-attachments/assets/24cf26e5-0d69-4f88-83e5-e226e4483027" />
