### PR TITLE
lispbm: Fix `print` out-of-bounds read

### DIFF
--- a/main/lispif_vesc_extensions.c
+++ b/main/lispif_vesc_extensions.c
@@ -409,10 +409,11 @@ static bool is_symbol_true_false(lbm_value v) {
 
 static lbm_value ext_print(lbm_value *args, lbm_uint argn) {
 	const int str_len = 256;
-	char *print_val_buffer = lbm_malloc_reserve(str_len);
+	char *print_val_buffer = lbm_malloc_reserve(str_len + 1);
 	if (!print_val_buffer) {
 		return ENC_SYM_MERROR;
 	}
+	print_val_buffer[str_len] = '\0';
 
 	for (lbm_uint i = 0; i < argn; i ++) {
 		lbm_print_value(print_val_buffer, str_len, args[i]);


### PR DESCRIPTION
Fixes an out-of-bounds read in the `print` extension due to a missing null terminator. The issue is that the buffer allocated by the extension for the stringified value is given the same number of bytes as the limit given to the internal print function, which doesn't account for the null terminator.

This would cause garbaled output when a value which is stringified to a length >= 256 bytes is printed.

Fixes this by making the size of the allocated buffer one byte larger (257 bytes).

This doesn't seem like a very dangerous bug, but it results in some amusing output. :)

Here I first printed a string which resulted in 256 bytes being printed, and then a string which resulted in 255 bytes:
<img width="2480" height="628" alt="image" src="https://github.com/user-attachments/assets/4c7ed0ee-3ec8-4caf-823a-6b0dccb1153a" />
A condensed version for those who can't read very small text:
```
"aaa...<247 removed characters>...aaaa"c
B^ÔBù±¤Á(fb@'ÇÂ-SÍÂ3ÃÁ|"ÅÁçaBÑ1Bp%°B´åaÂM@À/¿ÂVå!ÃâÙÁìJÁE(BsØÐA¶B5Â@`Â¿~JÃxÂØéÁRB$»ÃANQYBhÀ¡Â4?À@­Á»ØzÃv9ÂV­£Á1~
> t
"aaa...<247 removed characters>...aaaa"c
B^ÔBù±¤Á(fb@'ÇÂ-SÍÂ3ÃÁ|"ÅÁçaBÑ1Bp%°B´åaÂM@À/¿ÂVå!ÃâÙÁìJÁE(BsØÐA¶B5Â@`Â¿~JÃxÂØéÁRB$»ÃANQYBhÀ¡Â4?À@­Á»ØzÃv9ÂV­£Á1~
> t
"aaa...<247 removed characters>...aaaa"c
B^ÔBù±¤Á(fb@'ÇÂ-SÍÂ3ÃÁ|"ÅÁçaBÑ1Bp%°B´åaÂM@À/¿ÂVå!ÃâÙÁìJÁE(BsØÐA¶B5Â@`Â¿~JÃxÂØéÁRB$»ÃANQYBhÀ¡Â4?À@­Á»ØzÃv9ÂV­£Á1~
> t
"aaa...<247 removed characters>...aaaa"c
B^ÔBù±¤Á(fb@'ÇÂ-SÍÂ3ÃÁ|"ÅÁçaBÑ1Bp%°B´åaÂM@À/¿ÂVå!ÃâÙÁìJÁE(BsØÐA¶B5Â@`Â¿~JÃxÂØéÁRB$»ÃANQYBhÀ¡Â4?À@­Á»ØzÃv9ÂV­£Á1~
> t
"aaa...<247 removed characters>...aaaa"c
B^ÔBù±¤Á(fb@'ÇÂ-SÍÂ3ÃÁ|"ÅÁçaBÑ1Bp%°B´åaÂM@À/¿ÂVå!ÃâÙÁìJÁE(BsØÐA¶B5Â@`Â¿~JÃxÂØéÁRB$»ÃANQYBhÀ¡Â4?À@­Á»ØzÃv9ÂV­£Á1~
> t
"aaa...<247 removed characters>...aaa"
> t
"aaa...<247 removed characters>...aaa"
> t
"aaa...<247 removed characters>...aaa"
> t
"aaa...<247 removed characters>...aaa"
> t
"aaa...<247 removed characters>...aaa"
> t
```

I've also confirmed that the bug is fixed after building new firmware.