### PR TITLE
Add the correct check efuse for S3 target

### DIFF
--- a/main/adc.c
+++ b/main/adc.c
@@ -68,6 +68,11 @@ void adc_init(void) {
 	if (adc_cali_create_scheme_curve_fitting(&cali_config, &adc1_cali_handle) == ESP_OK) {
 		cal_ok = true;
 	}
+	#elif CONFIG_IDF_TARGET_ESP32S3
+	if (esp_adc_cal_check_efuse(ESP_ADC_CAL_VAL_EFUSE_TP_FIT) == ESP_OK) {
+		esp_adc_cal_characterize(ADC_UNIT_1, ADC_ATTEN_DB_12, ADC_WIDTH_BIT_DEFAULT, 0, &adc1_chars);
+		cal_ok = true;
+	}
 	#else
 	if (esp_adc_cal_check_efuse(ESP_ADC_CAL_VAL_EFUSE_TP) == ESP_OK) {
 		esp_adc_cal_characterize(ADC_UNIT_1, ADC_ATTEN_DB_12, ADC_WIDTH_BIT_DEFAULT, 0, &adc1_chars);


### PR DESCRIPTION
ESP_ADC_CAL_VAL_EFUSE_TP is not available at the ESP32-S3 so the calibration always fails. cal_ok never gets true and get adc from LISP always returns -1.

This fix uses the correct define for ESP32-S3.