### PR TITLE
For discussion: Changes to how imports work 

### DIFF
--- a/main/lispif.c
+++ b/main/lispif.c
@@ -159,7 +159,7 @@ void lispif_init(void) {
 	}
 
 	lbm_mutex = xSemaphoreCreateMutex();
-	lispif_restart(false, true, true);
+	lispif_restart(false, true);
 
 #ifdef LBM_USE_TIME_QUOTA
 	lbm_set_eval_time_quota(2000);
@@ -251,7 +251,7 @@ void lispif_process_cmd(unsigned char *data, unsigned int len,
 		if (!running) {
 			ok = pause_eval(0, 2000);
 		} else {
-			ok = lispif_restart(true, true, true);
+			ok = lispif_restart(true, true);
 		}
 
 		int32_t ind = 0;
@@ -357,7 +357,7 @@ void lispif_process_cmd(unsigned char *data, unsigned int len,
 		}
 
 		if (!lisp_thd_running) {
-			lispif_restart(true, false, true);
+			lispif_restart(true, false);
 		}
 
 		if (lisp_thd_running) {
@@ -511,7 +511,7 @@ void lispif_process_cmd(unsigned char *data, unsigned int len,
 				}
 			} else if (strncmp(str, ":reset", 6) == 0) {
 				lispif_unlock_lbm();
-				commands_printf_lisp(lispif_restart(true, flash_helper_code_size(CODE_IND_LISP) > 0, true) ?
+				commands_printf_lisp(lispif_restart(true, flash_helper_code_size(CODE_IND_LISP) > 0) ?
 						"Reset OK\n\n" : "Reset Failed\n\n");
 				lispif_lock_lbm();
 			} else if (strncmp(str, ":pause", 6) == 0) {
@@ -602,11 +602,11 @@ void lispif_process_cmd(unsigned char *data, unsigned int len,
 
 		if (offset == 0) {
 			if (!lisp_thd_running) {
-				lispif_restart(true, restart == 2 ? true : false, true);
+				lispif_restart(true, restart == 2 ? true : false);
 			} else if (restart == 1) {
-				lispif_restart(true, false, true);
+				lispif_restart(true, false);
 			} else if (restart == 2) {
-				lispif_restart(true, true, true);
+				lispif_restart(true, true);
 			}
 		}
 
@@ -801,7 +801,7 @@ void lispif_stop(void) {
 	lispif_unlock_lbm();
 }
 
-bool lispif_restart(bool print, bool load_code, bool load_imports) {
+bool lispif_restart(bool print, bool load_code) {
 	bool res = false;
 
 	restart_cnt++;
@@ -869,9 +869,6 @@ bool lispif_restart(bool print, bool load_code, bool load_imports) {
 				running_app_info.app_elf_sha256[0], running_app_info.app_elf_sha256[1], running_app_info.app_elf_sha256[2], running_app_info.app_elf_sha256[3],
 				running_app_info.app_elf_sha256[4], running_app_info.app_elf_sha256[5], running_app_info.app_elf_sha256[6], running_app_info.app_elf_sha256[7]);
 
-			bool load_imports_before = load_imports;
-			load_imports = false;
-
 			if (!lbm_image_exists() || strcmp(lbm_image_get_version(), ver_str) != 0) {
 				commands_printf_lisp("Preparing new image...");
 				for (uint32_t i = 0; i < image_len;i++) {
@@ -879,7 +876,6 @@ bool lispif_restart(bool print, bool load_code, bool load_imports) {
 				}
 				image_max_ind = 0;
 				lbm_image_create(ver_str);
-				load_imports = load_imports_before;
 				new_image_created = true;
 			}
 
@@ -922,34 +918,9 @@ bool lispif_restart(bool print, bool load_code, bool load_imports) {
 			ext_load_callbacks[i](main_found);
 		}
 
-		if (load_imports) {
-			if (code_len > code_chars + 3) {
-				int32_t ind = code_chars + 1;
-				uint16_t num_imports = buffer_get_uint16((uint8_t*)code_data, &ind);
-
-				if (num_imports > 0 && num_imports < 500) {
-					for (int i = 0;i < num_imports;i++) {
-						char *name = code_data + ind;
-						ind += strlen(name) + 1;
-						int32_t offset = buffer_get_int32((uint8_t*)code_data, &ind);
-						int32_t len = buffer_get_int32((uint8_t*)code_data, &ind);
-
-						// Bounds check first
-						if (offset < 0 || len < 0
-							|| (int64_t)offset + len > (int64_t)code_len) {
-							continue;
-						}
-
-						lbm_value val;
-						if (lbm_share_array_const(&val, code_data + offset, len)) {
-							lbm_define(name, val);
-						}
-					}
-				}
-
-				lbm_image_save_global_env();
-			}
-		}
+		// Bundled imports are now bound lazily by ext_import (import extension)
+		// each time an (import "path" 'sym) line actually evaluates, instead
+		// of once here up front.
 
 		if (load_code) {
 			static lbm_string_channel_state_t string_tok_state;

--- a/main/lispif.h
+++ b/main/lispif.h
@@ -36,7 +36,7 @@ void lispif_lock_lbm(void);
 void lispif_unlock_lbm(void);
 void lispif_stop(void);
 void lispif_stop_lib(void);
-bool lispif_restart(bool print, bool load_code, bool load_imports);
+bool lispif_restart(bool print, bool load_code);
 void lispif_disable_all_events(void);
 void lispif_free(void *ptr);
 void lispif_process_cmd(unsigned char *data, unsigned int len,

--- a/main/lispif_vesc_extensions.c
+++ b/main/lispif_vesc_extensions.c
@@ -3659,7 +3659,7 @@ static lbm_value ext_sleep_config_wakeup_pin(lbm_value *args, lbm_uint argn) {
 
 	gpio_set_direction(pin, GPIO_MODE_INPUT);
 #if CONFIG_IDF_TARGET_ESP32S3
-	esp_sleep_enable_ext0_wakeup(pin, mode ? 1 : 0); 
+	esp_sleep_enable_ext0_wakeup(pin, mode ? 1 : 0);
 	esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
 #elif CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32C6 || CONFIG_IDF_TARGET_ESP32P4
 	esp_deep_sleep_enable_gpio_wakeup(1 << pin,mode ? ESP_GPIO_WAKEUP_GPIO_HIGH : ESP_GPIO_WAKEUP_GPIO_LOW);
@@ -3703,12 +3703,6 @@ static lbm_value ext_import(lbm_value *args, lbm_uint argn) {
 		return ENC_SYM_EERROR;
 	}
 
-	// Using the raw accessors here, not flash_helper_code_data_ptr()/
-	// flash_helper_code_size(): those gate on a cached check that gets
-	// invalidated by any flash write "before" the checked size, including
-	// the image-erase loop on a fresh-image boot -- before any lisp code,
-	// including this, ever runs. By the time import is actually evaluated
-	// the source is already known-good, since we're executing it.
 	const char *code_data = (const char*)flash_helper_code_data_raw(CODE_IND_LISP);
 	int32_t code_len = (int32_t)flash_helper_code_size_raw(CODE_IND_LISP);
 	if (!code_data || code_len <= 8) {
@@ -3751,10 +3745,6 @@ static lbm_value ext_import(lbm_value *args, lbm_uint argn) {
 			return ENC_SYM_MERROR;
 		}
 
-		// lbm_define() won't work here: it gates on the eval state being
-		// paused, which can never be true while we're running as an
-		// extension. Bind directly, the same way cont_set_global_env
-		// (eval_cps.c) does for a normal (def ...).
 		lbm_uint ix_key = sym_id & GLOBAL_ENV_MASK;
 		lbm_value *global_env = lbm_get_global_env();
 		lbm_value new_env_entry = lbm_env_set(global_env[ix_key], args[1], val);

--- a/main/lispif_vesc_extensions.c
+++ b/main/lispif_vesc_extensions.c
@@ -3687,6 +3687,92 @@ static lbm_value ext_empty(lbm_value *args, lbm_uint argn) {
 	return ENC_SYM_TRUE;
 }
 
+// (import "path" 'sym): the path is only used by VESC Tool at upload time
+// to bundle the file into the (name, offset, len) table appended after the
+// program's own source in the CODE_IND_LISP flash region. Looks sym up in
+// that table and shares the matching flash range as a const array.
+static lbm_value ext_import(lbm_value *args, lbm_uint argn) {
+	if (argn != 2 || !lbm_is_array_r(args[0]) || !lbm_is_symbol(args[1])) {
+		return ENC_SYM_TERROR;
+	}
+
+	lbm_uint sym_id = lbm_dec_sym(args[1]);
+	const char *sym_name = lbm_get_name_by_symbol(sym_id);
+	if (!sym_name) {
+		lbm_set_error_reason("import: could not look up the name of the destination symbol");
+		return ENC_SYM_EERROR;
+	}
+
+	// Using the raw accessors here, not flash_helper_code_data_ptr()/
+	// flash_helper_code_size(): those gate on a cached check that gets
+	// invalidated by any flash write "before" the checked size, including
+	// the image-erase loop on a fresh-image boot -- before any lisp code,
+	// including this, ever runs. By the time import is actually evaluated
+	// the source is already known-good, since we're executing it.
+	const char *code_data = (const char*)flash_helper_code_data_raw(CODE_IND_LISP);
+	int32_t code_len = (int32_t)flash_helper_code_size_raw(CODE_IND_LISP);
+	if (!code_data || code_len <= 8) {
+		lbm_set_error_reason("No program stored to import from");
+		return ENC_SYM_EERROR;
+	}
+	code_data += 8;
+	code_len -= 8;
+
+	int32_t code_chars = (int32_t)strnlen(code_data, (size_t)code_len);
+	if (code_len <= code_chars + 3) {
+		lbm_set_error_reason("No bundled imports found");
+		return ENC_SYM_EERROR;
+	}
+
+	int32_t ind = code_chars + 1;
+	uint16_t num_imports = buffer_get_uint16((uint8_t*)code_data, &ind);
+	if (num_imports == 0 || num_imports >= 500) {
+		lbm_set_error_reason("No bundled imports found");
+		return ENC_SYM_EERROR;
+	}
+
+	for (int i = 0; i < num_imports; i++) {
+		const char *name = code_data + ind;
+		ind += (int32_t)strnlen(name, (size_t)(code_len - ind)) + 1;
+		int32_t offset = buffer_get_int32((uint8_t*)code_data, &ind);
+		int32_t len = buffer_get_int32((uint8_t*)code_data, &ind);
+
+		if (strcmp(name, sym_name) != 0) {
+			continue;
+		}
+
+		if (offset < 0 || len < 0 || (int64_t)offset + len > (int64_t)code_len) {
+			lbm_set_error_reason("Bundled import has an invalid offset/length");
+			return ENC_SYM_EERROR;
+		}
+
+		lbm_value val;
+		if (!lbm_share_array_const(&val, (char*)(code_data + offset), (lbm_uint)len)) {
+			return ENC_SYM_MERROR;
+		}
+
+		// lbm_define() won't work here: it gates on the eval state being
+		// paused, which can never be true while we're running as an
+		// extension. Bind directly, the same way cont_set_global_env
+		// (eval_cps.c) does for a normal (def ...).
+		lbm_uint ix_key = sym_id & GLOBAL_ENV_MASK;
+		lbm_value *global_env = lbm_get_global_env();
+		lbm_value new_env_entry = lbm_env_set(global_env[ix_key], args[1], val);
+		if (lbm_is_symbol_merror(new_env_entry)) {
+			return ENC_SYM_MERROR;
+		}
+		if (lbm_is_symbol(new_env_entry)) {
+			lbm_set_error_reason("import: could not bind the destination symbol");
+			return ENC_SYM_EERROR;
+		}
+		global_env[ix_key] = new_env_entry;
+		return ENC_SYM_TRUE;
+	}
+
+	lbm_set_error_reason("Symbol not found among bundled imports");
+	return ENC_SYM_EERROR;
+}
+
 // Remote Messages
 #define RMSG_SLOT_NUM	8
 
@@ -6768,7 +6854,7 @@ void lispif_load_vesc_extensions(bool main_found) {
 		lbm_add_extension("send-data", ext_send_data);
 		lbm_add_extension("recv-data", ext_recv_data);
 		lbm_add_extension("sysinfo", ext_sysinfo);
-		lbm_add_extension("import", ext_empty);
+		lbm_add_extension("import", ext_import);
 		lbm_add_extension("main-init-done", ext_main_init_done);
 		lbm_add_extension("crc16", ext_crc16);
 		lbm_add_extension("crc32", ext_crc32);


### PR DESCRIPTION
Some programs not using the image-save and main-function functionality end up crashing. 
These changes remove this problem in the case I could reproduce using the vdisp900. 

The problem: 
1. upon upload of a program to flash from Vesc tool, imports are resolved and defines are created on the lisp environment. 
2.  The environment is saved so that upon an image boot we can again know where the imports are. 
3.  Adding the environment bindings also added lisp-value header-wrappers  to the const heap! This is because the import data is const (so const arrays in total).
4. the const-heap-pointer was not saved as part of this process. 
5. no image-save, no main

Upon reboot we find a state where there are things written to the const-heap, and the const-heap-pointer is 0. and the things that are stored on the const-heap cannot be recreated by the reader because they were created by the RTS at upload time.  

This PR Changes how imports are resolved so that it happens at runtime when the (import ...) extension is called by the lisp program.  ext_import will lookup there imported data and create the environment bindings. 

It is possible that just storing the const_heap_pointer at the upload (after the env was saved) would have fixed this too. This approach could lead to the environment (at least parts of it) being duplicated in flash. 