### PR TITLE
Added HW conf for Seeed Studio XAIO-ESP32-C3

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -132,6 +132,7 @@ set(COMPONENT_ADD_INCLUDEDIRS
 "hwconf/rescue"
 "hwconf/avaspark"
 "hwconf/vesc/vbms_inf_sat"
+"hwconf/seeed"
 
 "lispBM"
 "lispBM/include"

--- a/main/hwconf/seeed/README.md
+++ b/main/hwconf/seeed/README.md
@@ -1,0 +1,10 @@
+# Seeed ESP32C3 Hardware Configuration
+
+HW conf for Seeed Studio XAIO-ESP32-C3
+Use together with a CAN bus transceiver for example: SN65HVD230
+
+D0 => CAN transceiver RX\
+D1 => CAN transceiver TX
+
+build:\
+`idf.py build -DHW_NAME="Seeed ESP32-C3"`

--- a/main/hwconf/seeed/hw_seeed_esp32c3.c
+++ b/main/hwconf/seeed/hw_seeed_esp32c3.c
@@ -1,0 +1,1 @@
+#include "hw_seeed_esp32c3.h"

--- a/main/hwconf/seeed/hw_seeed_esp32c3.h
+++ b/main/hwconf/seeed/hw_seeed_esp32c3.h
@@ -1,0 +1,19 @@
+#ifndef MAIN_HWCONF_SEEED_HW_SEEED_ESP32C3_H_
+#define MAIN_HWCONF_SEEED_HW_SEEED_ESP32C3_H_
+
+#define HW_NAME						"Seeed ESP32-C3"
+#define HW_TARGET					"esp32c3"
+
+#define HW_INIT_HOOK()
+
+// CAN
+#define CAN_TX_GPIO_NUM				3 // Pin D1 (GPIO3)
+#define CAN_RX_GPIO_NUM				2 // Pin D0 (GPIO2)
+
+// UART
+#define UART_NUM					0
+#define UART_BAUDRATE				115200
+#define UART_TX						21
+#define UART_RX						20
+
+#endif /* MAIN_HWCONF_SEEED_HW_SEEED_ESP32C3_H_ */


### PR DESCRIPTION
Added HW conf for Seeed Studio XAIO-ESP32-C3
Use together with a  CAN bus transceiver for example: SN65HVD230

D0 => CAN transceiver RX
D1 => CAN transceiver TX

build using:
`idf.py build -DHW_NAME="Seeed ESP32-C3"`

